### PR TITLE
Images SDK: add a test which uses a image object directly (instead of a file path)

### DIFF
--- a/tests/functional/eyes_images/test_functional.py
+++ b/tests/functional/eyes_images/test_functional.py
@@ -1,9 +1,9 @@
 # from applitools.core import Region, UnscaledFixedCutProvider
 from os import path
 
-from applitools.core import Region
+from PIL import Image
 
-from applitools.images import Target
+from applitools.images import Region, Target
 
 here = path.abspath(path.dirname(__file__))
 
@@ -14,15 +14,22 @@ def test_check_image(eyes):
     eyes.close()
 
 
-def test_check_image_fluent(eyes):
+def test_check_image_path_fluent(eyes):
     eyes.open('images', 'TestCheckImage_Fluent')
     eyes.check("TestCheckImage_Fluent", Target().image(path.join(here, "resources/minions-800x500.jpg")))
     eyes.close()
 
 
+def test_check_raw_image_fluent(eyes):
+    eyes.open('images', 'TestCheckImage_Fluent')
+    eyes.check("TestCheckImage_Fluent", Target().image(Image.new('RGBA', (600, 600))))
+    eyes.close()
+
+
 def test_check_image_with_ignore_region_fluent(eyes):
     eyes.open('images', 'TestCheckImageWithIgnoreRegion_Fluent')
-    eyes.check("TestCheckImage_WithIgnoreRegion_Fluent", Target().image(path.join(here, "resources/minions-800x500.jpg"))
+    eyes.check("TestCheckImage_WithIgnoreRegion_Fluent",
+               Target().image(path.join(here, "resources/minions-800x500.jpg"))
                .ignore(Region(10, 20, 30, 40)))
     eyes.close()
 


### PR DESCRIPTION
https://trello.com/c/5qSaIVgi/409-images-sdk-add-a-test-which-uses-a-image-object-directly-instead-of-a-file-path