### PR TITLE
Selenium backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,177 @@ geckodriver.log
 *.egg-info
 .directory
 .python-version
+build/*
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/eyes_selenium/applitools/common.py
+++ b/eyes_selenium/applitools/common.py
@@ -1,0 +1,6 @@
+from .core import logger  # noqa
+from .selenium import StitchMode  # noqa
+
+logger.deprecation(
+    "Will be deprecated in version 4.0. Import from `applitools.selenium` instead"
+)

--- a/eyes_selenium/applitools/errors.py
+++ b/eyes_selenium/applitools/errors.py
@@ -1,0 +1,7 @@
+from .core import logger  # noqa
+from .core.errors import *  # noqa
+
+logger.deprecation(
+    "Will be deprecated in version 4.0. Import from `applitools.core` or "
+    "`applitools.selenium` instead"
+)

--- a/eyes_selenium/applitools/eyes.py
+++ b/eyes_selenium/applitools/eyes.py
@@ -1,0 +1,13 @@
+from .core import logger  # noqa
+from .selenium import (  # noqa
+    BatchInfo,
+    ExactMatchSettings,
+    Eyes,
+    FailureReports,
+    MatchLevel,
+)
+
+logger.deprecation(
+    "Will be deprecated in version 4.0. Import from `applitools.core` or "
+    "`applitools.selenium` instead"
+)

--- a/eyes_selenium/applitools/geometry.py
+++ b/eyes_selenium/applitools/geometry.py
@@ -1,0 +1,7 @@
+from .core import logger  # noqa
+from .core.geometry import *  # noqa
+
+logger.deprecation(
+    "Will be deprecated in version 4.0. Import from  "
+    "`applitools.core` or `applitools.selenium` instead"
+)

--- a/eyes_selenium/applitools/logger.py
+++ b/eyes_selenium/applitools/logger.py
@@ -1,0 +1,6 @@
+from .core import logger  # noqa
+from .core.logger import *  # noqa
+
+logger.deprecation(
+    "Will be deprecated in version 4.0. Import from  `applitools.core` instead"
+)

--- a/eyes_selenium/applitools/target.py
+++ b/eyes_selenium/applitools/target.py
@@ -1,0 +1,6 @@
+from .core import logger  # noqa
+from .selenium.target import *  # noqa
+
+logger.deprecation(
+    "Will be deprecated in version 4.0. Import from  `applitools.selenium` instead"
+)

--- a/eyes_selenium/applitools/utils.py
+++ b/eyes_selenium/applitools/utils.py
@@ -1,0 +1,6 @@
+from .core import logger  # noqa
+from .core.utils import general_utils, image_utils  # noqa
+
+logger.deprecation(
+    "Will be deprecated in version 4.0. Import from  `applitools.core` instead"
+)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -64,5 +64,5 @@ def test_eyes_selenium_old_namespace(virtualenv):
     virtualenv.run('python -c "from applitools.logger import StdoutLogger"')
     virtualenv.run('python -c "from applitools.errors import EyesError"')
     virtualenv.run(
-        'python -c "from applitools.utils import general_utils, ' 'image_utils"'
+        'python -c "from applitools.utils import general_utils, image_utils"'
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,3 +52,17 @@ def test_eyes_selenium_namespace_package(virtualenv):
     virtualenv.install_package(_packages_resolver(core=True), build_egg=True)
     virtualenv.install_package(_packages_resolver(selenium=True), build_egg=True)
     virtualenv.run('python -c "from applitools.selenium import *"')
+
+
+def test_eyes_selenium_old_namespace(virtualenv):
+    virtualenv.install_package(_packages_resolver(core=True), build_egg=True)
+    virtualenv.install_package(_packages_resolver(selenium=True), build_egg=True)
+    virtualenv.run('python -c "from applitools.eyes import Eyes"')
+    virtualenv.run('python -c "from applitools.target import Target"')
+    virtualenv.run('python -c "from applitools.common import StitchMode"')
+    virtualenv.run('python -c "from applitools.geometry import Point, Region"')
+    virtualenv.run('python -c "from applitools.logger import StdoutLogger"')
+    virtualenv.run('python -c "from applitools.errors import EyesError"')
+    virtualenv.run(
+        'python -c "from applitools.utils import general_utils, ' 'image_utils"'
+    )


### PR DESCRIPTION
This PR allow adding compatibility with an old way of importing and fix the error raised during use of both eyes_images and eyes_selenium packages.

The old way of importing such as `from applitools.eyes import Eyes; from applitools.target import Target` was changed into prefer `from applitools.selenium import Eyes, Target`. This PR adds compatibility for the old way of importing in eyes.sdk repo. So this repo could be used without the need to modify and deploy from eyes.selenium.