### PR TITLE
fix-sending-match-level

### DIFF
--- a/eyes_common/applitools/common/config/configuration.py
+++ b/eyes_common/applitools/common/config/configuration.py
@@ -84,7 +84,7 @@ class Configuration(object):
     properties = attr.ib(factory=list)
     hide_scrollbars = attr.ib(default=False)
     match_timeout = attr.ib(default=DEFAULT_MATCH_TIMEOUT)
-    match_level = attr.ib(default=MatchLevel.STRICT)  # TODO add converter to enum
+    match_level = attr.ib(default=MatchLevel.STRICT, converter=MatchLevel)
     is_disabled = attr.ib(default=False)
     save_new_tests = attr.ib(default=True)
     save_failed_tests = attr.ib(default=False)

--- a/eyes_common/applitools/common/match.py
+++ b/eyes_common/applitools/common/match.py
@@ -88,30 +88,30 @@ class ImageMatchSettings(object):
     """
 
     match_level = attr.ib(
-        default=MatchLevel.STRICT, metadata={JsonInclude.NON_NONE: True}
+        default=MatchLevel.STRICT, metadata={JsonInclude.THIS: True}
     )  # type: MatchLevel
     exact = attr.ib(
-        default=None, type=ExactMatchSettings, metadata={JsonInclude.NON_NONE: True}
+        default=None, type=ExactMatchSettings, metadata={JsonInclude.THIS: True}
     )  # type: Optional[ExactMatchSettings]
-    ignore_caret = attr.ib(default=None, metadata={JsonInclude.NON_NONE: True})
-    send_dom = attr.ib(default=False, metadata={JsonInclude.NON_NONE: True})
-    use_dom = attr.ib(default=False, metadata={JsonInclude.NON_NONE: True})
-    enable_patterns = attr.ib(default=False, metadata={JsonInclude.NON_NONE: True})
+    ignore_caret = attr.ib(default=False, metadata={JsonInclude.THIS: True})
+    send_dom = attr.ib(default=False, metadata={JsonInclude.THIS: True})
+    use_dom = attr.ib(default=False, metadata={JsonInclude.THIS: True})
+    enable_patterns = attr.ib(default=False, metadata={JsonInclude.THIS: True})
 
     ignore = attr.ib(
-        factory=list, type=typing.List[Region], metadata={JsonInclude.NON_NONE: True}
+        factory=list, type=typing.List[Region], metadata={JsonInclude.THIS: True}
     )
     layout = attr.ib(
-        factory=list, type=typing.List[Region], metadata={JsonInclude.NON_NONE: True}
+        factory=list, type=typing.List[Region], metadata={JsonInclude.THIS: True}
     )
     strict = attr.ib(
-        factory=list, type=typing.List[Region], metadata={JsonInclude.NON_NONE: True}
+        factory=list, type=typing.List[Region], metadata={JsonInclude.THIS: True}
     )
     content = attr.ib(
-        factory=list, type=typing.List[Region], metadata={JsonInclude.NON_NONE: True}
+        factory=list, type=typing.List[Region], metadata={JsonInclude.THIS: True}
     )
     floating = attr.ib(
-        factory=list, type=typing.List[Region], metadata={JsonInclude.NON_NONE: True}
+        factory=list, type=typing.List[Region], metadata={JsonInclude.THIS: True}
     )
 
 

--- a/eyes_core/applitools/core/eyes_base.py
+++ b/eyes_core/applitools/core/eyes_base.py
@@ -22,7 +22,7 @@ from applitools.common.match import MatchResult
 from applitools.common.metadata import AppEnvironment, SessionStartInfo
 from applitools.common.server import FailureReports, SessionType
 from applitools.common.test_results import TestResults
-from applitools.common.utils import ABC, argument_guard
+from applitools.common.utils import ABC, argument_guard, general_utils
 from applitools.common.visual_grid import RenderingInfo
 from applitools.core.capture import AppOutputProvider, AppOutputWithScreenshot
 from applitools.core.cut import NullCutProvider
@@ -671,17 +671,25 @@ class EyesBase(_EyesBaseAbstract):
         if check_settings:
             retry_timeout = check_settings.values.timeout
 
-        default_match_settings = self.configuration.default_match_settings
+        get_config_value = general_utils.use_default_if_none_factory(
+            self.configuration.default_match_settings, self.configuration
+        )
         # Set defaults if necessary
-        if check_settings:
-            if check_settings.values.match_level is None:
-                check_settings = check_settings.match_level(
-                    default_match_settings.match_level
-                )
-            if check_settings.values.ignore_caret is None:
-                check_settings = check_settings.ignore_caret(
-                    default_match_settings.ignore_caret
-                )
+        if check_settings.values.match_level is None:
+            check_settings = check_settings.match_level(get_config_value("match_level"))
+        if check_settings.values.ignore_caret is None:
+            check_settings = check_settings.ignore_caret(
+                get_config_value("ignore_caret")
+            )
+        if check_settings.values.send_dom is None:
+            check_settings = check_settings.ignore_caret(get_config_value("send_dom"))
+        if check_settings.values.use_dom is None:
+            check_settings = check_settings.ignore_caret(get_config_value("use_dom"))
+        if check_settings.values.enable_patterns is None:
+            check_settings = check_settings.ignore_caret(
+                get_config_value("enable_patterns")
+            )
+
         region = region_provider.get_region()
         logger.debug("params: ([{}], {}, {})".format(region, tag, retry_timeout))
 

--- a/eyes_core/applitools/core/match_window_task.py
+++ b/eyes_core/applitools/core/match_window_task.py
@@ -9,7 +9,7 @@ from applitools.common.errors import OutOfBoundsError
 from applitools.common.geometry import Region
 from applitools.common.match import ImageMatchSettings
 from applitools.common.match_window_data import MatchWindowData, Options
-from applitools.common.utils import general_utils, image_utils
+from applitools.common.utils import image_utils
 from applitools.common.visual_grid import VisualGridSelector
 from applitools.core.capture import AppOutputProvider, AppOutputWithScreenshot
 
@@ -67,28 +67,6 @@ def collect_regions_from_screenshot(
     )
     image_match_settings.floating = _collect_regions(  # type: ignore
         check_settings.values.floating_regions, screenshot, eyes
-    )
-    return image_match_settings
-
-
-def create_image_match_settings(check_settings, eyes):
-    # type: (CheckSettings, EyesBase) -> ImageMatchSettings
-    default = general_utils.use_default_if_none_factory(
-        eyes.configuration.default_match_settings, check_settings.values
-    )
-    match_level = default("match_level")
-    ignore_caret = default("ignore_caret")
-    send_dom = default("send_dom")
-    use_dom = default("use_dom")
-    enable_patterns = default("enable_patterns")
-
-    image_match_settings = ImageMatchSettings(
-        match_level=match_level,
-        exact=None,
-        ignore_caret=ignore_caret,
-        send_dom=send_dom,
-        use_dom=use_dom,
-        enable_patterns=enable_patterns,
     )
     return image_match_settings
 
@@ -292,12 +270,19 @@ class MatchWindowTask(object):
         app_output = self._app_output_provider.get_app_output(
             region, self._last_screenshot, check_settings
         )
-        match_settings = create_image_match_settings(check_settings, self._eyes)
+        image_match_settings = ImageMatchSettings(
+            match_level=check_settings.values.match_level,
+            exact=None,
+            ignore_caret=check_settings.values.ignore_caret,
+            send_dom=check_settings.values.send_dom,
+            use_dom=check_settings.values.use_dom,
+            enable_patterns=check_settings.values.enable_patterns,
+        )
         self._match_result = self.perform_match(
             app_output,
             tag,
             ignore_mismatch,
-            match_settings,
+            image_match_settings,
             self._eyes,
             user_inputs,
             check_settings=check_settings,

--- a/eyes_selenium/applitools/selenium/eyes.py
+++ b/eyes_selenium/applitools/selenium/eyes.py
@@ -54,7 +54,6 @@ class Eyes(object):
     _selenium_eyes = None  # type: SeleniumEyes
     _runner = None  # type: Optional[VisualGridRunner]
     _driver = None  # type: Optional[EyesWebDriver]
-    _configuration = SeleniumConfiguration()  # type: SeleniumConfiguration
 
     @property
     def configuration(self):
@@ -71,6 +70,8 @@ class Eyes(object):
 
     def __init__(self, runner=None):
         # type: (Optional[Any]) -> None
+        self._configuration = SeleniumConfiguration()  # type: SeleniumConfiguration
+
         # backward compatibility with settings server_url
         if isinstance(runner, str):
             self.configuration.server_url = runner

--- a/eyes_selenium/applitools/selenium/visual_grid/resource_cache.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/resource_cache.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 import typing
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -20,7 +21,10 @@ lock = threading.RLock()
 class ResourceCache(typing.Mapping[typing.Text, VGResource]):
     def __init__(self):
         self.cache_map = {}
-        self.executor = ThreadPoolExecutor(thread_name_prefix="ResourceCache-Executor")
+        kwargs = {}
+        if sys.version_info >= (3, 6):
+            kwargs["thread_name_prefix"] = "ResourceCache-Executor"
+        self.executor = ThreadPoolExecutor(**kwargs)
 
     def __str__(self):
         return str(self.cache_map)[:25]

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
@@ -1,3 +1,4 @@
+import sys
 import concurrent
 import itertools
 import operator
@@ -24,9 +25,11 @@ class VisualGridRunner(object):
     def __init__(self, concurrent_sessions=None):
         # type: (Optional[int]) -> None
         self.concurrent_sessions = concurrent_sessions
-        self.executor = ThreadPoolExecutor(
-            max_workers=concurrent_sessions, thread_name_prefix="VGR-Executor"
-        )
+        kwargs = {}
+        if sys.version_info >= (3, 6):
+            kwargs["thread_name_prefix"] = "VGR-Executor"
+
+        self.executor = ThreadPoolExecutor(max_workers=concurrent_sessions, **kwargs)
         self._rendering_info = None  # type: Optional[RenderingInfo]
         self.resource_cache = ResourceCache()
         self.put_cache = ResourceCache()

--- a/tests/unit/eyes_selenium/test_eyes.py
+++ b/tests/unit/eyes_selenium/test_eyes.py
@@ -25,8 +25,9 @@ def test_set_get_scale_ratio(eyes):
     eyes.scale_ratio = 2.0
     assert eyes.scale_ratio == 2.0
 
-    eyes.scale_ratio = None
-    assert eyes.scale_ratio == NullScaleProvider.UNKNOWN_SCALE_RATIO
+    if not eyes._is_visual_grid_eyes:
+        eyes.scale_ratio = None
+        assert eyes.scale_ratio == NullScaleProvider.UNKNOWN_SCALE_RATIO
 
 
 def test_match_level(eyes):

--- a/tests/unit/eyes_selenium/test_eyes.py
+++ b/tests/unit/eyes_selenium/test_eyes.py
@@ -1,18 +1,24 @@
 import pytest
+from applitools.common import MatchLevel
 
 from applitools.core import NullScaleProvider
 from applitools.selenium import Eyes
 from applitools.selenium.visual_grid import VisualGridRunner
 
 
-@pytest.fixture(scope="function")
-def eyes():
-    return Eyes()
+def pytest_generate_tests(metafunc):
+    if "eyes" in metafunc.fixturenames:
+        metafunc.parametrize("eyes", ["selenium", "visual_grid"], indirect=True)
 
 
 @pytest.fixture(scope="function")
-def vg_eyes():
-    return Eyes(VisualGridRunner())
+def eyes(request):
+    if request.param == "selenium":
+        return Eyes()
+    elif request.param == "visual_grid":
+        return Eyes(VisualGridRunner())
+    else:
+        raise ValueError("invalid internal test config")
 
 
 def test_set_get_scale_ratio(eyes):
@@ -23,6 +29,9 @@ def test_set_get_scale_ratio(eyes):
     assert eyes.scale_ratio == NullScaleProvider.UNKNOWN_SCALE_RATIO
 
 
-def test_initialization():
-    eyes = Eyes()
-    eyes
+def test_match_level(eyes):
+    assert eyes.match_level == MatchLevel.STRICT
+    eyes.match_level = MatchLevel.EXACT
+    assert eyes.match_level == MatchLevel.EXACT
+    eyes.match_level = MatchLevel.LAYOUT
+    assert eyes.match_level == MatchLevel.LAYOUT

--- a/tests/unit/eyes_selenium/test_eyes.py
+++ b/tests/unit/eyes_selenium/test_eyes.py
@@ -33,11 +33,15 @@ def test_match_level(eyes):
     assert eyes.match_level == MatchLevel.STRICT
     eyes.match_level = MatchLevel.EXACT
     assert eyes.match_level == MatchLevel.EXACT
+    assert eyes.configuration.match_level == MatchLevel.EXACT
     eyes.match_level = MatchLevel.LAYOUT
     assert eyes.match_level == MatchLevel.LAYOUT
+    assert eyes.configuration.match_level == MatchLevel.LAYOUT
 
 
 def test_stitch_mode(eyes):
     assert eyes.stitch_mode == StitchMode.Scroll
+    assert eyes.configuration.stitch_mode == StitchMode.Scroll
     eyes.stitch_mode = StitchMode.CSS
     assert eyes.stitch_mode == StitchMode.CSS
+    assert eyes.configuration.stitch_mode == StitchMode.CSS

--- a/tests/unit/eyes_selenium/test_eyes.py
+++ b/tests/unit/eyes_selenium/test_eyes.py
@@ -1,5 +1,5 @@
 import pytest
-from applitools.common import MatchLevel
+from applitools.common import MatchLevel, StitchMode
 
 from applitools.core import NullScaleProvider
 from applitools.selenium import Eyes
@@ -35,3 +35,9 @@ def test_match_level(eyes):
     assert eyes.match_level == MatchLevel.EXACT
     eyes.match_level = MatchLevel.LAYOUT
     assert eyes.match_level == MatchLevel.LAYOUT
+
+
+def test_stitch_mode(eyes):
+    assert eyes.stitch_mode == StitchMode.Scroll
+    eyes.stitch_mode = StitchMode.CSS
+    assert eyes.stitch_mode == StitchMode.CSS


### PR DESCRIPTION
Users cannot override the match level. Setting eyes.match_level = MatchLevel.LAYOUT always comes back as Strict. 