### PR TITLE
Many frame and screenshot related fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,12 @@ jobs:
           env:
               - TOX_ENV=images
         - python: 3.6
-#          env:
-#              - TOX_ENV=selenium-on-windows-remote
-#        - python: 3.6
-#          env:
-#              - TOX_ENV=selenium-on-macos-remote
-#        - python: 3.6
+          env:
+              - TOX_ENV=selenium-on-windows-remote
+        - python: 3.6
+          env:
+              - TOX_ENV=selenium-on-macos-remote
+        - python: 3.6
           env:
               - TOX_ENV=selenium-appium-remote
         - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
+services:
+  - xvfb
 install:
     - pip install -U tox
 before_script:
     # Run GUI apps in headless mode
     - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
     - sleep 10 # give webdriver some time to start
     - export APPLITOOLS_BATCH_ID=`uuidgen -t`
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,12 @@ jobs:
         - python: 3.6
           env:
               - TOX_ENV=images
-        - python: 3.6
-          env:
-              - TOX_ENV=selenium-on-windows-remote
-        - python: 3.6
-          env:
-              - TOX_ENV=selenium-on-macos-remote
+#        - python: 3.6
+#          env:
+#              - TOX_ENV=selenium-on-windows-remote
+#        - python: 3.6
+#          env:
+#              - TOX_ENV=selenium-on-macos-remote
         - python: 3.6
           env:
               - TOX_ENV=selenium-appium-remote

--- a/eyes_common/applitools/common/capture.py
+++ b/eyes_common/applitools/common/capture.py
@@ -102,7 +102,11 @@ class EyesScreenshot(ABC):
 
         updated_location = self.convert_location(region.location, from_, to)
         return Region(
-            updated_location.x, updated_location.y, region.width, region.height
+            updated_location.x,
+            updated_location.y,
+            region.width,
+            region.height,
+            coordinates_type=to,
         )
 
     @property

--- a/eyes_common/applitools/common/config/configuration.py
+++ b/eyes_common/applitools/common/config/configuration.py
@@ -99,7 +99,7 @@ class Configuration(object):
         default=ImageMatchSettings()
     )  # type: ImageMatchSettings
     hide_caret = attr.ib(init=False, default=None)  # type: Optional[bool]
-    stitching_overlap = attr.ib(init=False, default=10)  # type: int
+    stitching_overlap = attr.ib(init=False, default=5)  # type: int
 
     api_key = attr.ib(
         factory=lambda: os.getenv("APPLITOOLS_API_KEY", None)

--- a/eyes_common/applitools/common/config/configuration.py
+++ b/eyes_common/applitools/common/config/configuration.py
@@ -99,7 +99,7 @@ class Configuration(object):
         default=ImageMatchSettings()
     )  # type: ImageMatchSettings
     hide_caret = attr.ib(init=False, default=None)  # type: Optional[bool]
-    stitching_overlap = attr.ib(init=False, default=50)  # type: int
+    stitching_overlap = attr.ib(init=False, default=10)  # type: int
 
     api_key = attr.ib(
         factory=lambda: os.getenv("APPLITOOLS_API_KEY", None)

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -464,12 +464,12 @@ class Region(DictAccessMixin):
 
     @overload  # noqa
     def offset(self, location):
-        # type: (Point) -> Point
+        # type: (Point) -> Region
         pass
 
     @overload  # noqa
     def offset(self, dx, dy):
-        # type: (int, int) -> Point
+        # type: (int, int) -> Region
         pass
 
     def offset(self, location_or_dx, dy=None):  # noqa

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -510,5 +510,5 @@ class Region(DictAccessMixin):
             top=int(math.ceil(self.top * scale_ratio)),
             width=int(math.ceil(self.width * scale_ratio)),
             height=int(math.ceil(self.height * scale_ratio)),
-            coordinates_type=self.coordinates_typeF,
+            coordinates_type=self.coordinates_type,
         )

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -323,7 +323,9 @@ class Region(DictAccessMixin):
         Returns:
             The cloned instance of Region.
         """
-        return Region(self.left, self.top, self.width, self.height)
+        return Region(
+            self.left, self.top, self.width, self.height, self.coordinates_type
+        )
 
     def make_empty(self):
         """Sets the current instance as an empty instance"""
@@ -440,7 +442,13 @@ class Region(DictAccessMixin):
                 current_width = current_right - current_left
 
                 sub_regions.append(
-                    Region(current_left, current_top, current_width, current_height)
+                    Region(
+                        current_left,
+                        current_top,
+                        current_width,
+                        current_height,
+                        coordinates_type=self.coordinates_type,
+                    )
                 )
 
                 current_left += max_sub_region_size["width"]
@@ -482,6 +490,7 @@ class Region(DictAccessMixin):
             top=location.y,
             width=self.size["width"],
             height=self.size["height"],
+            coordinates_type=self.coordinates_type,
         )
 
     def scale(self, scale_ratio):
@@ -501,4 +510,5 @@ class Region(DictAccessMixin):
             top=int(math.ceil(self.top * scale_ratio)),
             width=int(math.ceil(self.width * scale_ratio)),
             height=int(math.ceil(self.height * scale_ratio)),
+            coordinates_type=self.coordinates_typeF,
         )

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -112,15 +112,15 @@ class Point(DictAccessMixin):
         return "Point({x} x {y})".format(x=self.x, y=self.y)
 
     def __add__(self, other):
-        # type: (Point) -> Point
-        return Point(self.x + other.x, self.y + other.y)
-
-    def __iadd__(self, other):
-        # type: (Point) -> Point
+        # type: (Union[Point, int, float]) -> Point
+        if isinstance(other, int) or isinstance(other, float):
+            return Point(self.x + round(other), self.y + round(other))
         return Point(self.x + other.x, self.y + other.y)
 
     def __sub__(self, other):
-        # type: (Point) -> Point
+        # type: (Union[Point, int, float]) -> Point
+        if isinstance(other, int) or isinstance(other, float):
+            return Point(self.x - round(other), self.y - round(other))
         return Point(self.x - other.x, self.y - other.y)
 
     def __mul__(self, scalar):

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -355,29 +355,29 @@ class Region(DictAccessMixin):
         """
         return self.left == self.top == self.width == self.height == 0
 
-    def contains(self, pt):
+    def contains(self, other):
         # type: (Union[Point, Region]) -> bool
         """Return true if a point is inside the rectangle.
 
         Args:
-            pt: element for check
+            other: element for check
 
         Returns:
             True if the point is inside the rectangle. Otherwise False.
         """
-        if isinstance(pt, Point):
-            x, y = pt
+        if isinstance(other, Point):
+            x, y = other
             return self.left <= x <= self.right and self.top <= y <= self.bottom  # noqa
         else:
             right = self.left + self.width
-            pt_right = pt.left + pt.width
+            pt_right = other.left + other.width
 
             bottom = self.top + self.height
-            pt_bottom = pt.top + pt.height
+            pt_bottom = other.top + other.height
 
             return (
-                self.top <= pt.top
-                and self.left <= pt.left
+                self.top <= other.top
+                and self.left <= other.left
                 and bottom >= pt_bottom
                 and right >= pt_right
             )
@@ -443,10 +443,10 @@ class Region(DictAccessMixin):
 
                 sub_regions.append(
                     Region(
-                        current_left,
-                        current_top,
-                        current_width,
-                        current_height,
+                        left=current_left,
+                        top=current_top,
+                        width=current_width,
+                        height=current_height,
                         coordinates_type=self.coordinates_type,
                     )
                 )

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -417,7 +417,7 @@ class Region(DictAccessMixin):
         self.width = intersection_right - intersection_left
         self.height = intersection_bottom - intersection_top
 
-    def get_sub_regions(
+    def get_sub_regions(  # noqa
         self,
         max_sub_region_size,  # type: RectangleSize
         logical_overlap,  # type: int

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -123,6 +123,10 @@ class Point(DictAccessMixin):
             return Point(self.x - round(other), self.y - round(other))
         return Point(self.x - other.x, self.y - other.y)
 
+    def __neg__(self):
+        # type: () -> Point
+        return Point(-self.x, -self.y)
+
     def __mul__(self, scalar):
         # type: (int) -> Point
         return Point(self.x * scalar, self.y * scalar)

--- a/eyes_core/applitools/core/__init__.py
+++ b/eyes_core/applitools/core/__init__.py
@@ -21,7 +21,7 @@ from .positioning import (
     NULL_REGION_PROVIDER,
     InvalidPositionProvider,
     NullRegionProvider,
-    PositionMomento,
+    PositionMemento,
     PositionProvider,
     RegionProvider,
 )
@@ -44,7 +44,7 @@ __all__ = (
     "ScaleProvider",
     "EyesBase",
     "PositionProvider",
-    "PositionMomento",
+    "PositionMemento",
     "InvalidPositionProvider",
     "RegionProvider",
     "FixedCutProvider",

--- a/eyes_core/applitools/core/cut.py
+++ b/eyes_core/applitools/core/cut.py
@@ -1,10 +1,11 @@
 import math
 from abc import abstractmethod
+from typing import Dict, Union
 
 import attr
 from PIL.Image import Image
 
-from applitools.common import Region
+from applitools.common import RectangleSize, Region
 from applitools.common.utils import ABC, image_utils
 
 __all__ = ("FixedCutProvider", "UnscaledFixedCutProvider", "NullCutProvider")
@@ -34,6 +35,15 @@ class CutProvider(ABC):
     def scale(self, scale_ratio):
         # type: (float) -> CutProvider
         """Get a scaled version of the cut provider"""
+
+    def to_region(self, size):
+        # type: (Union[RectangleSize, Dict]) -> Region
+        return Region(
+            left=self.left,
+            top=self.header,
+            width=size["width"] - self.left - self.right,
+            height=size["height"] - self.header - self.footer,
+        )
 
 
 class FixedCutProvider(CutProvider):

--- a/eyes_core/applitools/core/eyes_base.py
+++ b/eyes_core/applitools/core/eyes_base.py
@@ -522,9 +522,7 @@ class EyesBase(_EyesBaseAbstract):
             raise EyesError("A test is already running")
 
     def _log_open_base(self):
-        logger.debug(
-            "Eyes server URL is '{}'".format(self._server_connector.server_url)
-        )
+        logger.debug("Eyes server URL is '{}'".format(self.configuration.server_url))
         logger.debug("Timeout = {} ms".format(self.configuration.timeout))
         logger.debug("match_timeout = {} ms".format(self.configuration.match_timeout))
         logger.debug(

--- a/eyes_core/applitools/core/positioning/__init__.py
+++ b/eyes_core/applitools/core/positioning/__init__.py
@@ -1,6 +1,6 @@
 from .position_provider import (  # noqa: F401
     InvalidPositionProvider,
-    PositionMomento,
+    PositionMemento,
     PositionProvider,
 )
 from .region_provider import (  # noqa: F401

--- a/eyes_core/applitools/core/positioning/position_provider.py
+++ b/eyes_core/applitools/core/positioning/position_provider.py
@@ -11,7 +11,7 @@ if typing.TYPE_CHECKING:
     from applitools.common import RectangleSize
 
 
-class PositionMomento(object):
+class PositionMemento(object):
     """
     A base class for position related memento instances. This is intentionally
     not an interface, since the mementos might vary in their interfaces.
@@ -24,12 +24,12 @@ class PositionMomento(object):
             setattr(self, name, val)
 
     def __str__(self):
-        return "PositionMomento(position={}, ...)".format(self.position)
+        return "PositionMemento(position={}, ...)".format(self.position)
 
 
 @attr.s
 class PositionProvider(ABC):
-    _states = attr.ib(init=False, factory=list)  # type: List[PositionMomento]
+    _states = attr.ib(init=False, factory=list)  # type: List[PositionMemento]
     _last_set_position = attr.ib(init=False, default=None)  # type: Point
 
     @abc.abstractmethod
@@ -59,7 +59,7 @@ class PositionProvider(ABC):
         """
         Adds the current position to the states list.
         """
-        self._states.append(PositionMomento(self.get_current_position()))
+        self._states.append(PositionMemento(self.get_current_position()))
 
     def pop_state(self):
         """
@@ -71,7 +71,7 @@ class PositionProvider(ABC):
 
     @property
     def states(self):
-        # type: () -> List[PositionMomento]
+        # type: () -> List[PositionMemento]
         return self._states
 
     def __enter__(self):

--- a/eyes_core/applitools/core/positioning/position_provider.py
+++ b/eyes_core/applitools/core/positioning/position_provider.py
@@ -1,8 +1,6 @@
 import abc
 import typing
 
-import attr
-
 from applitools.common.geometry import Point
 from applitools.common.utils import ABC, iteritems
 
@@ -27,12 +25,7 @@ class PositionMemento(object):
         return "PositionMemento(position={}, ...)".format(self.position)
 
 
-@attr.s
 class PositionProvider(ABC):
-    _states = attr.ib(init=False, factory=list)  # type: List[PositionMemento]
-    _last_set_position = attr.ib(init=False, default=None)  # type: Point
-    _state_index = -1
-
     @abc.abstractmethod
     def get_current_position(self):
         # type: () -> Optional[Point]

--- a/eyes_core/applitools/core/positioning/position_provider.py
+++ b/eyes_core/applitools/core/positioning/position_provider.py
@@ -18,7 +18,7 @@ class PositionMomento(object):
     """
 
     def __init__(self, position, **kwargs):
-        # type: (PositionProvider, **Any) -> None
+        # type: (Point, **Any) -> None
         self.position = position
         for name, val in iteritems(kwargs):
             setattr(self, name, val)

--- a/eyes_core/applitools/core/positioning/position_provider.py
+++ b/eyes_core/applitools/core/positioning/position_provider.py
@@ -31,6 +31,7 @@ class PositionMemento(object):
 class PositionProvider(ABC):
     _states = attr.ib(init=False, factory=list)  # type: List[PositionMemento]
     _last_set_position = attr.ib(init=False, default=None)  # type: Point
+    _state_index = -1
 
     @abc.abstractmethod
     def get_current_position(self):
@@ -60,12 +61,14 @@ class PositionProvider(ABC):
         Adds the current position to the states list.
         """
         self._states.append(PositionMemento(self.get_current_position()))
+        self._state_index += 1
 
     def pop_state(self):
         """
         Sets the position to be the last position added to the states list.
         """
         state = self._states.pop()
+        self._state_index -= 1
         self.set_position(state.position)
         self._last_set_position = state.position
 
@@ -73,6 +76,13 @@ class PositionProvider(ABC):
     def states(self):
         # type: () -> List[PositionMemento]
         return self._states
+
+    @property
+    def current_state(self):
+        # type: () -> PositionMemento
+        if self._state_index >= 0:
+            return self._states[self._state_index]
+        return PositionMemento(self.get_current_position())
 
     def __enter__(self):
         self.push_state()

--- a/eyes_core/applitools/core/positioning/position_provider.py
+++ b/eyes_core/applitools/core/positioning/position_provider.py
@@ -57,6 +57,7 @@ class PositionProvider(ABC):
         """
 
     def push_state(self):
+        # type: () -> PositionMemento
         """
         Adds the current position to the states list.
         """

--- a/eyes_core/applitools/core/positioning/position_provider.py
+++ b/eyes_core/applitools/core/positioning/position_provider.py
@@ -60,8 +60,10 @@ class PositionProvider(ABC):
         """
         Adds the current position to the states list.
         """
-        self._states.append(PositionMemento(self.get_current_position()))
+        state = PositionMemento(self.get_current_position())
+        self._states.append(state)
         self._state_index += 1
+        return state
 
     def pop_state(self):
         """
@@ -79,10 +81,10 @@ class PositionProvider(ABC):
 
     @property
     def current_state(self):
-        # type: () -> PositionMemento
+        # type: () -> Optional[PositionMemento]
         if self._state_index >= 0:
             return self._states[self._state_index]
-        return PositionMemento(self.get_current_position())
+        return None
 
     def __enter__(self):
         self.push_state()

--- a/eyes_core/applitools/core/positioning/position_provider.py
+++ b/eyes_core/applitools/core/positioning/position_provider.py
@@ -56,44 +56,31 @@ class PositionProvider(ABC):
         :return: The entire size of the container which the position is relative to.
         """
 
-    def push_state(self):
+    def get_state(self):
         # type: () -> PositionMemento
-        """
-        Adds the current position to the states list.
-        """
-        state = PositionMemento(self.get_current_position())
-        self._states.append(state)
-        self._state_index += 1
-        return state
+        """Get the current state of the position provider.
 
-    def pop_state(self):
+        This is different from :eyes_selenium_utils:`get_current_position()` in that the
+        state of the position provider
+        might include other model than just the coordinates. For example a CSS
+        translation based position provider (in WebDriver based SDKs), might
+        save the entire "transform" style value as its state.
+
+        Returns:
+            The current state of the position provider, which can later be
+            restored by  passing it as a parameter to :self:`restore_state`.
         """
-        Sets the position to be the last position added to the states list.
+        return PositionMemento(self.get_current_position())
+
+    def restore_state(self, state):
+        # type: (PositionMemento) -> None
+        """ Restores the state of the position provider to the state provided as a
+        parameter.
+
+        Args:
+            state: The state to restore to.
         """
-        state = self._states.pop()
-        self._state_index -= 1
         self.set_position(state.position)
-        self._last_set_position = state.position
-
-    @property
-    def states(self):
-        # type: () -> List[PositionMemento]
-        return self._states
-
-    @property
-    def current_state(self):
-        # type: () -> Optional[PositionMemento]
-        if self._state_index >= 0:
-            return self._states[self._state_index]
-        return None
-
-    def __enter__(self):
-        self.push_state()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.pop_state()
-        return self
 
 
 class InvalidPositionProvider(PositionProvider):

--- a/eyes_core/applitools/core/positioning/region_provider.py
+++ b/eyes_core/applitools/core/positioning/region_provider.py
@@ -1,4 +1,5 @@
 import typing as tp
+from typing import Callable, Union
 
 import attr
 
@@ -16,7 +17,7 @@ class RegionProvider(ABC):
     used.
     """
 
-    _region = attr.ib()  # type: Region
+    _region = attr.ib()  # type: Union[Region, Callable]
 
     def get_region(self, eyes_screenshot=None):
         # type: (tp.Optional[EyesScreenshot]) -> Region

--- a/eyes_selenium/applitools/selenium/capture/dom_capture.py
+++ b/eyes_selenium/applitools/selenium/capture/dom_capture.py
@@ -157,7 +157,7 @@ def get_full_window_dom(driver, return_as_dict=False):
         driver.execute_script(_CAPTURE_FRAME_SCRIPT, _ARGS_OBJ),
         object_pairs_hook=OrderedDict,
     )
-    current_root_element = eyes_selenium_utils.current_frame_scroll_root_element(driver)
+    current_root_element = eyes_selenium_utils.curr_frame_scroll_root_element(driver)
 
     with ScrollPositionProvider(driver, current_root_element):
         logger.debug("Traverse DOM Tree")

--- a/eyes_selenium/applitools/selenium/capture/dom_capture.py
+++ b/eyes_selenium/applitools/selenium/capture/dom_capture.py
@@ -159,7 +159,9 @@ def get_full_window_dom(driver, return_as_dict=False):
     )
     current_root_element = eyes_selenium_utils.curr_frame_scroll_root_element(driver)
 
-    with ScrollPositionProvider(driver, current_root_element):
+    with eyes_selenium_utils.get_and_restore_state(
+        ScrollPositionProvider(driver, current_root_element)
+    ):
         logger.debug("Traverse DOM Tree")
         _traverse_dom_tree(driver, {"childNodes": [dom_tree], "tagName": "OUTER_HTML"})
 

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -210,10 +210,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
                 from_ == self.CONTEXT_RELATIVE or from_ == self.CONTEXT_AS_IS
             ) and to == self.SCREENSHOT_AS_IS:
                 # If this is not a sub-screenshot, this will have no effect.
-                result = result.offset(
-                    self._frame_location_in_screenshot.x,
-                    self._frame_location_in_screenshot.y,
-                )
+                result = result.offset(self._frame_location_in_screenshot)
                 # If this is not a region subscreenshot, this will have no effect.
                 result = result.offset(
                     -self.region_window.left, -self.region_window.top
@@ -221,61 +218,34 @@ class EyesWebDriverScreenshot(EyesScreenshot):
             elif from_ == self.SCREENSHOT_AS_IS and (
                 to == self.CONTEXT_RELATIVE or to == self.CONTEXT_AS_IS
             ):
-                result = result.offset(
-                    -self._frame_location_in_screenshot.x,
-                    -self._frame_location_in_screenshot.y,
-                )
+                result = result.offset(-self._frame_location_in_screenshot)
             return result
 
         if from_ == self.CONTEXT_AS_IS:
             if to == self.CONTEXT_RELATIVE:
-                result = result.offset(
-                    self._current_frame_scroll_position.x,
-                    self._current_frame_scroll_position.y,
-                )
+                result = result.offset(self._current_frame_scroll_position)
             elif to == self.SCREENSHOT_AS_IS:
-                result = result.offset(
-                    self._frame_location_in_screenshot.x,
-                    self._frame_location_in_screenshot.y,
-                )
+                result = result.offset(self._frame_location_in_screenshot)
             else:
                 raise CoordinatesTypeConversionError(from_, to)
         elif from_ == self.CONTEXT_RELATIVE:
             if to == self.SCREENSHOT_AS_IS:
                 # First, convert context-relative to context-as-is.
-                result = result.offset(
-                    -self._current_frame_scroll_position.x,
-                    -self._current_frame_scroll_position.y,
-                )
+                result = result.offset(-self._current_frame_scroll_position)
                 # Now convert context-as-is to screenshot-as-is
-                result = result.offset(
-                    self._frame_location_in_screenshot.x,
-                    self._frame_location_in_screenshot.y,
-                )
+                result = result.offset(self._frame_location_in_screenshot)
             elif to == self.CONTEXT_AS_IS:
-                result = result.offset(
-                    -self._current_frame_scroll_position.x,
-                    -self._current_frame_scroll_position.y,
-                )
+                result = result.offset(-self._current_frame_scroll_position)
             else:
                 raise CoordinatesTypeConversionError(from_, to)
         elif from_ == self.SCREENSHOT_AS_IS:
             if to == self.CONTEXT_RELATIVE:
                 # First, convert context-relative to context-as-is.
-                result = result.offset(
-                    -self._frame_location_in_screenshot.x,
-                    -self._frame_location_in_screenshot.y,
-                )
+                result = result.offset(-self._frame_location_in_screenshot)
                 # Now convert context-as-is to screenshot-as-is
-                result = result.offset(
-                    self._current_frame_scroll_position.x,
-                    self._current_frame_scroll_position.y,
-                )
+                result = result.offset(self._current_frame_scroll_position)
             elif to == self.CONTEXT_AS_IS:
-                result = result.offset(
-                    -self._frame_location_in_screenshot.x,
-                    -self._frame_location_in_screenshot.y,
-                )
+                result = result.offset(-self._frame_location_in_screenshot)
             else:
                 raise CoordinatesTypeConversionError(from_, to)
         else:

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -210,9 +210,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
     @staticmethod
     def _get_default_content_scroll_position(driver):
         # type: (EyesWebDriver) -> Point
-        scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
-            driver
-        )
+        scroll_root_element = eyes_selenium_utils.curr_frame_scroll_root_element(driver)
         return eyes_selenium_utils.get_current_position(driver, scroll_root_element)
 
     @staticmethod

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -110,18 +110,12 @@ class EyesWebDriverScreenshot(EyesScreenshot):
             )
         else:
             self.frame_chain = FrameChain()
-            self._current_frame_scroll_position = Point(0, 0)
-            self._frame_location_in_screenshot = Point(0, 0)
-            self.frame_window = Region.from_location_size(
-                self._frame_location_in_screenshot,
-                Region.from_location_size(
-                    self._frame_location_in_screenshot,
-                    dict(width=self.image.width, height=self.image.height),
-                ),
+            self._current_frame_scroll_position = Point.ZERO()
+            self._frame_location_in_screenshot = Point.ZERO()
+            self.frame_window = Region.from_(
+                self._frame_location_in_screenshot, self.image
             )
-        self.frame_window.intersect(
-            Region(0, 0, width=self.image.width, height=self.image.height)
-        )
+        self.frame_window.intersect(Region.from_(self.image))
 
     def _validate_frame_window(self):
         # type: () -> None

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -20,15 +20,12 @@ from applitools.common.utils import argument_guard, image_utils
 from applitools.core.capture import EyesScreenshot, EyesScreenshotFactory
 from applitools.selenium import eyes_selenium_utils
 from applitools.selenium.frames import FrameChain
-from applitools.selenium.positioning import (
-    ScrollPositionProvider,
-    SeleniumPositionProvider,
-)
 
 if typing.TYPE_CHECKING:
     from typing import Optional, Union
     from PIL import Image
     from applitools.selenium.webdriver import EyesWebDriver
+    from applitools.selenium.positioning import SeleniumPositionProvider
 
 
 class ScreenshotType(Enum):
@@ -190,9 +187,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
         scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
             driver
         )
-        return ScrollPositionProvider.get_current_position_static(
-            driver, scroll_root_element
-        )
+        return eyes_selenium_utils.get_current_position(driver, scroll_root_element)
 
     @staticmethod
     def get_default_content_scroll_position(current_frames, driver):

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -19,6 +19,7 @@ from applitools.common import (
 from applitools.common.utils import argument_guard, image_utils
 from applitools.core.capture import EyesScreenshot, EyesScreenshotFactory
 from applitools.selenium import eyes_selenium_utils
+from applitools.selenium.frames import FrameChain
 from applitools.selenium.positioning import (
     ScrollPositionProvider,
     SeleniumPositionProvider,
@@ -28,7 +29,6 @@ if typing.TYPE_CHECKING:
     from typing import Optional, Union
     from PIL import Image
     from applitools.selenium.webdriver import EyesWebDriver
-    from applitools.selenium.frames import FrameChain
 
 
 class ScreenshotType(Enum):
@@ -109,7 +109,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
                 self._frame_location_in_screenshot, frame_size
             )
         else:
-            self.frame_chain = FrameChain()
+            self._frame_chain = FrameChain()
             self._current_frame_scroll_position = Point.ZERO()
             self._frame_location_in_screenshot = Point.ZERO()
             self.frame_window = Region.from_(

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -33,6 +33,46 @@ class ScreenshotType(Enum):
     ENTIRE_FRAME = "ENTIRE_FRAME"
 
 
+def get_cur_position_provider(driver):
+    # type: (EyesWebDriver) -> SeleniumPositionProvider
+    cur_frame_position_provider = driver.eyes.current_frame_position_provider
+    if cur_frame_position_provider:
+        return cur_frame_position_provider
+    else:
+        return driver.eyes.position_provider
+
+
+def get_updated_scroll_position(position_provider):
+    # type: (SeleniumPositionProvider) -> Point
+    try:
+        sp = position_provider.get_current_position()
+        if not sp:
+            sp = Point.ZERO()
+    except WebDriverException:
+        sp = Point.ZERO()
+
+    return sp
+
+
+def update_screenshot_type(screenshot_type, image, driver):
+    # type: ( Optional[ScreenshotType], Image, EyesWebDriver) -> ScreenshotType
+    if screenshot_type is None:
+        viewport_size = driver.eyes.viewport_size
+        scale_viewport = driver.eyes.stitch_content
+
+        if scale_viewport:
+            pixel_ratio = driver.eyes.device_pixel_ratio
+            viewport_size = viewport_size.scale(pixel_ratio)
+        if (
+            image.width <= viewport_size["width"]
+            and image.height <= viewport_size["height"]
+        ):
+            screenshot_type = ScreenshotType.VIEWPORT
+        else:
+            screenshot_type = ScreenshotType.ENTIRE_FRAME
+    return screenshot_type
+
+
 @attr.s
 class EyesWebDriverScreenshot(EyesScreenshot):
 
@@ -48,6 +88,25 @@ class EyesWebDriverScreenshot(EyesScreenshot):
     @classmethod
     def create_viewport(cls, driver, image):
         # type: (EyesWebDriver, Image.Image) -> EyesWebDriverScreenshot
+
+        # Some browsers return always full page screenshot (IE).
+        # So we cut such images to viewport size
+        if not driver.is_mobile_app:
+            position_provider = get_cur_position_provider(driver)
+            curr_frame_scroll = get_updated_scroll_position(position_provider)
+            screenshot_type = update_screenshot_type(None, image, driver)
+            if screenshot_type != ScreenshotType.VIEWPORT:
+                viewport_size = driver.eyes.viewport_size
+                image = image_utils.crop_image(
+                    image,
+                    region_to_crop=Region(
+                        top=curr_frame_scroll.x,
+                        left=0,
+                        height=viewport_size["height"],
+                        width=viewport_size["width"],
+                    ),
+                )
+
         instance = cls(driver, image, ScreenshotType.VIEWPORT, None)
         instance._validate_frame_window()
         return instance
@@ -83,19 +142,15 @@ class EyesWebDriverScreenshot(EyesScreenshot):
 
     def __attrs_post_init__(self):
         # type: () -> None
-        self._screenshot_type = self.update_screenshot_type(
-            self._screenshot_type, self._image
+        self._screenshot_type = update_screenshot_type(
+            self._screenshot_type, self._image, self._driver
         )
-        cur_frame_position_provider = self._driver.eyes.current_frame_position_provider
-        if cur_frame_position_provider:
-            position_provider = cur_frame_position_provider
-        else:
-            position_provider = self._driver.eyes.position_provider
+        position_provider = get_cur_position_provider(self._driver)
 
         if not self._driver.is_mobile_app:
             self._frame_chain = self._driver.frame_chain.clone()
             frame_size = self.get_frame_size(position_provider)
-            self._current_frame_scroll_position = self.get_updated_scroll_position(
+            self._current_frame_scroll_position = get_updated_scroll_position(
                 position_provider
             )
             self.updated_frame_location_in_screenshot(
@@ -130,35 +185,6 @@ class EyesWebDriverScreenshot(EyesScreenshot):
                 self._frame_location_in_screenshot = Point.ZERO()
         else:
             self._frame_location_in_screenshot = location
-
-    def get_updated_scroll_position(self, position_provider):
-        # type: (SeleniumPositionProvider) -> Point
-        try:
-            sp = position_provider.get_current_position()
-            if not sp:
-                sp = Point.ZERO()
-        except WebDriverException:
-            sp = Point.ZERO()
-
-        return sp
-
-    def update_screenshot_type(self, screenshot_type, image):
-        # type: ( Optional[ScreenshotType], Image) -> ScreenshotType
-        if screenshot_type is None:
-            viewport_size = self._driver.eyes.viewport_size
-            scale_viewport = self._driver.eyes.stitch_content
-
-            if scale_viewport:
-                pixel_ratio = self._driver.eyes.device_pixel_ratio
-                viewport_size = viewport_size.scale(pixel_ratio)
-            if (
-                image.width <= viewport_size["width"]
-                and image.height <= viewport_size["height"]
-            ):
-                screenshot_type = ScreenshotType.VIEWPORT
-            else:
-                screenshot_type = ScreenshotType.ENTIRE_FRAME
-        return screenshot_type
 
     @property
     def image(self):

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -97,7 +97,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
 
         if not self._driver.is_mobile_app:
             self._frame_chain = self._driver.frame_chain.clone()
-
+            frame_size = self.get_frame_size(position_provider)
             self._current_frame_scroll_position = self.get_updated_scroll_position(
                 position_provider
             )
@@ -105,7 +105,6 @@ class EyesWebDriverScreenshot(EyesScreenshot):
                 self._frame_location_in_screenshot
             )
             logger.debug("Calculating frame window...")
-            frame_size = self.get_frame_size(position_provider)
             self.frame_window = Region.from_(
                 self._frame_location_in_screenshot, frame_size
             )

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -91,7 +91,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
         if not self._driver.is_mobile_app:
             self._frame_chain = self._driver.frame_chain.clone()
             frame_size = self.get_frame_size(position_provider)
-            self._current_frame_scroll_position = eyes_selenium_utils.get_updated_scroll_position(
+            self._current_frame_scroll_position = eyes_selenium_utils.get_updated_scroll_position(  # noqa
                 position_provider
             )
             self.updated_frame_location_in_screenshot(

--- a/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
+++ b/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
@@ -338,6 +338,6 @@ class FullPageCaptureAlgorithm(object):
         # Handling a specific case where the region is actually larger than
         # the screenshot (e.g., when body width/height are set to 100%, and
         # an internal div is set to value which is larger than the viewport).
-        region_in_screenshot.intersect(Region(0, 0, image.width, image.height))
+        region_in_screenshot.intersect(Region.from_(image))
         logger.info("Region after intersect: {}".format(region_in_screenshot))
         return region_in_screenshot

--- a/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
+++ b/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
@@ -173,10 +173,9 @@ class FullPageCaptureAlgorithm(object):
             )
             origin_position = stitch_provider.set_position(part_region_location)
 
-            # dx = part_region_location.x - origin_position.x
-            # dy = part_region_location.y - origin_position.y
-            dx, dy = part_region_location - origin_position
-            target_position = part_region.paste_physical_location.offset(dx, dy)
+            target_position = part_region.paste_physical_location.offset(
+                part_region_location - origin_position
+            )
 
             # Actually taking the screenshot.
             sleep(self.wait_before_screenshots / 1000.0)

--- a/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
+++ b/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
@@ -49,7 +49,7 @@ class FullPageCaptureAlgorithm(object):
         logger.info("get_stitched_region()")
         logger.info("PositionProvider: %s ; Region: %s" % (position_provider, region))
 
-        self.origin_provider.push_state()
+        origin_state = self.origin_provider.get_state()
 
         if not self.origin_provider == position_provider:
             self.origin_provider.set_position(
@@ -58,7 +58,7 @@ class FullPageCaptureAlgorithm(object):
 
         # Saving the original position (in case we were already in the outermost frame).
         logger.info("Getting top/left image...")
-        original_stitched_state = position_provider.push_state()
+        original_stitched_state = position_provider.get_state()
 
         initial_screenshot = self.image_provider.get_image()
         initial_size = RectangleSize.from_(initial_screenshot)
@@ -89,7 +89,7 @@ class FullPageCaptureAlgorithm(object):
                 scaled_initial_screenshot.width >= entire_size.width
                 and scaled_initial_screenshot.height >= entire_size.height
             ):
-                self.origin_provider.pop_state()
+                self.origin_provider.restore_state(origin_state)
                 return scaled_initial_screenshot
 
             full_area = Region.from_(Point.ZERO(), entire_size)
@@ -156,8 +156,8 @@ class FullPageCaptureAlgorithm(object):
             self.scale_provider.scale_ratio,
             scaled_cut_provider,
         )
-        position_provider.pop_state()
-        self.origin_provider.pop_state()
+        position_provider.restore_state(original_stitched_state)
+        self.origin_provider.restore_state(origin_state)
         return stitched_image
 
     def _stitch_screenshot(

--- a/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
+++ b/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
@@ -51,7 +51,7 @@ class FullPageCaptureAlgorithm(object):
 
         origin_state = self.origin_provider.get_state()
 
-        if not self.origin_provider == position_provider:
+        if self.origin_provider != position_provider:
             self.origin_provider.set_position(
                 Point.ZERO()
             )  # first scroll to 0,0 so CSS stitching works.

--- a/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
+++ b/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
@@ -122,7 +122,8 @@ class FullPageCaptureAlgorithm(object):
             height=scaled_cropped_source_region["height"],
         )
 
-        # Getting the list of viewport regions composing the page (we'll take screenshot for each one).
+        # Getting the list of viewport regions composing the page
+        # (we'll take screenshot for each one).
         if region_in_screenshot.is_empty:
             x = max(0, full_area.left)
             y = max(0, full_area.top)

--- a/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
+++ b/eyes_selenium/applitools/selenium/capture/full_page_capture_algorithm.py
@@ -1,17 +1,20 @@
+import math
 import typing
+from time import sleep
 
 import attr
 from PIL import Image
 from selenium.common.exceptions import WebDriverException
 
 from applitools.common import CoordinatesType, Point, RectangleSize, Region, logger
+from applitools.common.geometry import SubregionForStitching
 from applitools.common.utils import argument_guard, image_utils
-from applitools.core import PositionProvider
+from applitools.core import PositionMemento, PositionProvider
 from applitools.core.cut import NullCutProvider
 from applitools.selenium.capture import EyesWebDriverScreenshot
 
 if typing.TYPE_CHECKING:
-    from typing import Optional, List
+    from typing import Optional, List, Dict
     from applitools.core.scaling import ScaleProvider
     from applitools.core.debug import DebugScreenshotProvider
     from applitools.selenium.region_compensation import RegionPositionCompensation
@@ -21,7 +24,7 @@ if typing.TYPE_CHECKING:
 
 @attr.s
 class FullPageCaptureAlgorithm(object):
-    MIN_SCREENSHOT_PART_HEIGHT = 10
+    MIN_SCREENSHOT_PART_SIZE = 10
 
     wait_before_screenshots = attr.ib()  # type: int
     debug_screenshot_provider = attr.ib()  # type: DebugScreenshotProvider
@@ -46,95 +49,165 @@ class FullPageCaptureAlgorithm(object):
         logger.info("get_stitched_region()")
         logger.info("PositionProvider: %s ; Region: %s" % (position_provider, region))
 
-        with self.origin_provider:
+        self.origin_provider.push_state()
+
+        if not self.origin_provider == position_provider:
             self.origin_provider.set_position(
                 Point.ZERO()
             )  # first scroll to 0,0 so CSS stitching works.
 
-            # Saving the original position (in case we were already in the outermost frame).
-            with position_provider:
-                logger.info("Getting top/left image...")
-                image = self.image_provider.get_image()
-                self.debug_screenshot_provider.save(image, self._debug_msg("original"))
-                pixel_ratio = self._get_pixel_ratio(image)
-                scaled_cut_provider = self.cut_provider.scale(pixel_ratio)
-                image = self._cut_if_needed(image, scaled_cut_provider)
-                region_in_screenshot = self._get_region_in_screenshot(
-                    region, image, pixel_ratio
-                )
-                image = self._crop_if_needed(image, region_in_screenshot)
-                image = self._scale_if_needed(image, pixel_ratio)
-                if full_area is None or full_area.is_empty:
-                    entire_size = self._get_entire_size(image, position_provider)
-                    # Notice that this might still happen even if we used
-                    # "get_image_part", since "entire_page_size" might be that of a
-                    # frame
-                    if (
-                        image.width >= entire_size.width
-                        and image.height >= entire_size.height
-                    ):
-                        return image
+        # Saving the original position (in case we were already in the outermost frame).
+        logger.info("Getting top/left image...")
+        original_stitched_state = position_provider.current_state
 
-                    full_area = Region.from_(Point.ZERO(), entire_size)
-
-                image_parts = self._get_image_parts(full_area, image)
-
-                stitched_image = self._create_stitched_image(full_area, image)
-                # These will be used for storing the actual stitched size (it is
-                # sometimes less than the size extracted via "get_entire_size").
-                last_successful_location = Point.ZERO()
-                last_successful_part_size = RectangleSize.from_(image)
-
-                # Take screenshot and stitch for each screenshot part
-                logger.debug("Getting the rest of the image parts...")
-                part_image = None
-                for part_region in image_parts:
-                    logger.debug("Taking screenshot for %s" % part_region)
-
-                    # Scroll to the part's top/left
-                    origin_position = position_provider.set_position(
-                        part_region.location
-                    )
-                    target_position = origin_position.offset(
-                        -full_area.left, -full_area.top
-                    )
-                    logger.debug("Origin Position is set to %s" % origin_position)
-                    logger.debug("Target Position is %s" % target_position)
-
-                    # Actually taking the screenshot.
-                    logger.debug("Getting image...")
-                    part_image = self.image_provider.get_image()
-                    self.debug_screenshot_provider.save(
-                        part_image,
-                        self._debug_msg(
-                            "original-scrolled-{}".format(
-                                position_provider.get_current_position()
-                            )
-                        ),
-                    )
-                    part_image = self._cut_if_needed(part_image, scaled_cut_provider)
-                    part_image = self._crop_if_needed(part_image, region_in_screenshot)
-                    part_image = self._scale_if_needed(part_image, pixel_ratio)
-
-                    # Stitching the current part.
-                    stitched_image.paste(
-                        part_image, box=(target_position.x, target_position.y)
-                    )
-                    last_successful_location = origin_position
-
-                if part_image:
-                    last_successful_part_size = RectangleSize.from_(part_image)
-
-            logger.info("Stitching done!")
-        # If the actual image size is smaller than the extracted size, we crop the image.
-        stitched_image = self._crop_if_smaller(
-            full_area,
-            last_successful_location,
-            last_successful_part_size,
-            stitched_image,
+        initial_screenshot = self.image_provider.get_image()
+        initial_size = RectangleSize.from_(initial_screenshot)
+        self.debug_screenshot_provider.save(
+            initial_screenshot, self._debug_msg("initial")
         )
 
-        self.debug_screenshot_provider.save(stitched_image, self._debug_msg("stitched"))
+        pixel_ratio = self._get_pixel_ratio(initial_screenshot)
+        scaled_cut_provider = self.cut_provider.scale(pixel_ratio)
+        initial_screenshot = self._cut_if_needed(
+            initial_screenshot, scaled_cut_provider
+        )
+        region_in_screenshot = self._get_region_in_screenshot(
+            region, initial_screenshot, pixel_ratio
+        )
+        initial_screenshot = self._crop_if_needed(
+            initial_screenshot, region_in_screenshot
+        )
+        initial_screenshot = self._scale_if_needed(initial_screenshot, pixel_ratio)
+        if full_area is None or full_area.is_empty:
+            entire_size = self._get_entire_size(initial_screenshot, position_provider)
+            # Notice that this might still happen even if we used
+            # "get_image_part", since "entire_page_size" might be that of a
+            # frame
+            if (
+                initial_screenshot.width >= entire_size.width
+                and initial_screenshot.height >= entire_size.height
+            ):
+                self.origin_provider.pop_state()
+                return initial_screenshot
+
+            full_area = Region.from_(Point.ZERO(), entire_size)
+
+        scaled_cropped_location = full_area.location
+        physical_crop_location = Point(
+            int(math.ceil(scaled_cropped_location.x * pixel_ratio)),
+            int(math.ceil(scaled_cropped_location.y * pixel_ratio)),
+        )
+        if region_in_screenshot.is_empty:
+            physical_crop_size = RectangleSize(
+                initial_size.width - physical_crop_location.x,
+                initial_size.height - physical_crop_location.y,
+            )
+            source_region = Region.from_(physical_crop_location, physical_crop_size)
+        else:
+            # Starting with the screenshot we already captured at (0,0).
+            source_region = region_in_screenshot
+
+        scaled_cropped_source_rect = self.cut_provider.to_region(source_region.size)
+        scaled_cropped_source_rect = scaled_cropped_source_rect.offset(
+            source_region.left, source_region.top
+        )
+        scaled_cropped_source_region = dict(
+            x=int(math.ceil(scaled_cropped_source_rect.left / pixel_ratio)),
+            y=int(math.ceil(scaled_cropped_source_rect.top / pixel_ratio)),
+            width=int(math.ceil(scaled_cropped_source_rect.width / pixel_ratio)),
+            height=int(math.ceil(scaled_cropped_source_rect.height / pixel_ratio)),
+        )
+        scaled_cropped_size = dict(
+            width=scaled_cropped_source_region["width"],
+            height=scaled_cropped_source_region["height"],
+        )
+
+        # Getting the list of viewport regions composing the page (we'll take screenshot for each one).
+        if region_in_screenshot.is_empty:
+            x = max(0, full_area.left)
+            y = max(0, full_area.top)
+            w = min(full_area.width, scaled_cropped_size["width"])
+            h = min(full_area.height, scaled_cropped_size["height"])
+            rect_in_screenshot = Region(
+                round(x * pixel_ratio),
+                round(y * pixel_ratio),
+                round(w * pixel_ratio),
+                round(h * pixel_ratio),
+            )
+        else:
+            rect_in_screenshot = region_in_screenshot
+
+        screenshot_parts = self._get_image_parts(
+            full_area, scaled_cropped_size, pixel_ratio, rect_in_screenshot
+        )
+
+        stitched_image = self._create_stitched_image(full_area, initial_screenshot)
+        stitched_image = self._stitch_screenshot(
+            original_stitched_state,
+            position_provider,
+            screenshot_parts,
+            stitched_image,
+            self.scale_provider.scale_ratio,
+            scaled_cut_provider,
+        )
+        self.origin_provider.pop_state()
+        return stitched_image
+
+    def _stitch_screenshot(
+        self,
+        original_stitch_state,  # type: PositionMemento
+        stitch_provider,  # type: PositionProvider
+        screenshot_parts,  # type: List[SubregionForStitching]
+        stitched_image,  # type: Image.Image
+        scale_ratio,  # type: float
+        scaled_cut_provider,  # type: CutProvider
+    ):
+        # type: (...) -> Image
+        logger.info("enter: scale_ratio {}".format(scale_ratio))
+        for part_region in screenshot_parts:
+            logger.info("Part: {}".format(part_region))
+            # Scroll to the part's top/left
+            part_region_location = part_region.scroll_to.offset(
+                original_stitch_state.position
+            )
+            origin_position = stitch_provider.set_position(part_region_location)
+
+            # dx = part_region_location.x - origin_position.x
+            # dy = part_region_location.y - origin_position.y
+            dx, dy = part_region_location - origin_position
+            target_position = part_region.paste_physical_location.offset(dx, dy)
+
+            # Actually taking the screenshot.
+            sleep(self.wait_before_screenshots / 1000.0)
+            part_image = self.image_provider.get_image()
+            cut_part = scaled_cut_provider.cut(part_image)
+            r = part_region.physical_crop_area
+            if not r.is_size_empty:
+                cropped_part = image_utils.crop_image(cut_part, r)
+            else:
+                cropped_part = cut_part
+
+            r2 = part_region.logical_crop_area
+
+            scaled_part_image = image_utils.scale_image(cropped_part, scale_ratio)
+            scaled_cropped_part_image = image_utils.crop_image(scaled_part_image, r2)
+
+            self.debug_screenshot_provider.save(
+                part_image,
+                "partImage-{}_{}".format(origin_position.x, origin_position.y),
+            )
+            self.debug_screenshot_provider.save(
+                scaled_cropped_part_image,
+                "scaledCroppedPartImage-{}_{}".format(
+                    target_position.x, target_position.y
+                ),
+            )
+            logger.info("pasting part at {}".format(target_position))
+
+            stitched_image.paste(
+                scaled_cropped_part_image, box=(target_position.x, target_position.y)
+            )
+        self.debug_screenshot_provider.save(stitched_image, "stitched")
         return stitched_image
 
     def _crop_if_smaller(
@@ -219,26 +292,27 @@ class FullPageCaptureAlgorithm(object):
     def _get_pixel_ratio(self, image):
         # type: (Image) -> float
         self.scale_provider.update_scale_ratio(image.width)
-        pixel_ratio = 1 / self.scale_provider.scale_ratio
-        return pixel_ratio
+        return 1.0 / self.scale_provider.scale_ratio
 
-    def _get_image_parts(self, full_area, image):
-        # type: (Region, Image) -> List[Region]
+    def _get_image_parts(
+        self, full_area, scaled_cropped_size, pixel_ratio, rect_in_screenshot
+    ):
+        # type: (Region, Dict, float, Region) -> List[Region]
         # The screenshot part is a bit smaller than the screenshot size,
         # in order to eliminate duplicate bottom scroll bars, as well as fixed
         # position footers.
         part_image_size = RectangleSize(
-            image.width,
-            max(
-                [image.height - self.stitching_overlap, self.MIN_SCREENSHOT_PART_HEIGHT]
-            ),
+            max(scaled_cropped_size["width"], self.MIN_SCREENSHOT_PART_SIZE),
+            max(scaled_cropped_size["height"], self.MIN_SCREENSHOT_PART_SIZE),
         )
         logger.info(
             "entire page region: %s, image part size: %s" % (full_area, part_image_size)
         )
         # Getting the list of sub-regions composing the whole region (we'll take
         # screenshot for each one).
-        image_parts = full_area.get_sub_regions(part_image_size)  # type: Region
+        image_parts = full_area.get_sub_regions(
+            part_image_size, self.stitching_overlap, pixel_ratio, rect_in_screenshot
+        )
         return image_parts
 
     def _get_region_in_screenshot(self, region, image, pixel_ratio):

--- a/eyes_selenium/applitools/selenium/capture/screenshot_utils.py
+++ b/eyes_selenium/applitools/selenium/capture/screenshot_utils.py
@@ -65,20 +65,18 @@ def calc_frame_location_in_screenshot(driver, frame_chain, screenshot_type):
     )
     logger.info("Getting first frame...")
     first_frame = frame_chain[0]
-    location_in_screenshot = Point(first_frame.location.x, first_frame.location.y)
+    location_in_screenshot = Point.from_(first_frame.location)
+
     # We only need to consider the scroll of the default content if the screenshot is a
-    # viewport screenshot. If this is a full page screenshot, the frame location will
-    # not change anyway.
+    # viewport screenshot.If this is a full page screenshot, the frame location will not
+    # change anyway.
     if screenshot_type == ScreenshotType.VIEWPORT:
-        location_in_screenshot = location_in_screenshot.offset(
-            -window_scroll.x, -window_scroll.y
-        )
+        location_in_screenshot = location_in_screenshot.offset(-window_scroll)
 
     # For inner frames we must calculate the scroll
     inner_frames = frame_chain[1:]
     for frame in inner_frames:
         location_in_screenshot = location_in_screenshot.offset(
-            frame.location.x - frame.parent_scroll_position.x,
-            frame.location.y - frame.parent_scroll_position.y,
+            frame.location - frame.parent_scroll_position
         )
     return location_in_screenshot

--- a/eyes_selenium/applitools/selenium/capture/screenshot_utils.py
+++ b/eyes_selenium/applitools/selenium/capture/screenshot_utils.py
@@ -1,0 +1,84 @@
+from enum import Enum
+from typing import TYPE_CHECKING, Optional
+
+from applitools.common import Point, Region, logger
+from applitools.common.utils import image_utils
+from applitools.selenium import eyes_selenium_utils
+from applitools.selenium.eyes_selenium_utils import (
+    get_cur_position_provider,
+    get_updated_scroll_position,
+)
+
+if TYPE_CHECKING:
+    from PIL import Image
+    from applitools.selenium.webdriver import EyesWebDriver
+
+
+class ScreenshotType(Enum):
+    VIEWPORT = "VIEWPORT"
+    ENTIRE_FRAME = "ENTIRE_FRAME"
+
+
+def update_screenshot_type(screenshot_type, image, driver):
+    # type: ( Optional[ScreenshotType], Image, EyesWebDriver) -> ScreenshotType
+    if screenshot_type is None:
+        viewport_size = driver.eyes.viewport_size
+        scale_viewport = driver.eyes.stitch_content
+
+        if scale_viewport:
+            pixel_ratio = driver.eyes.device_pixel_ratio
+            viewport_size = viewport_size.scale(pixel_ratio)
+        if (
+            image.width <= viewport_size["width"]
+            and image.height <= viewport_size["height"]
+        ):
+            screenshot_type = ScreenshotType.VIEWPORT
+        else:
+            screenshot_type = ScreenshotType.ENTIRE_FRAME
+    return screenshot_type
+
+
+def cut_to_viewport_size_if_required(driver, image):
+    # type: (EyesWebDriver, Image) -> Image
+    # Some browsers return always full page screenshot (IE).
+    # So we cut such images to viewport size
+    position_provider = get_cur_position_provider(driver)
+    curr_frame_scroll = get_updated_scroll_position(position_provider)
+    screenshot_type = update_screenshot_type(None, image, driver)
+    if screenshot_type != ScreenshotType.VIEWPORT:
+        viewport_size = driver.eyes.viewport_size
+        image = image_utils.crop_image(
+            image,
+            region_to_crop=Region(
+                top=curr_frame_scroll.x,
+                left=0,
+                height=viewport_size["height"],
+                width=viewport_size["width"],
+            ),
+        )
+    return image
+
+
+def calc_frame_location_in_screenshot(driver, frame_chain, screenshot_type):
+    window_scroll = eyes_selenium_utils.get_default_content_scroll_position(
+        frame_chain, driver
+    )
+    logger.info("Getting first frame...")
+    first_frame = frame_chain[0]
+    location_in_screenshot = Point(first_frame.location.x, first_frame.location.y)
+    # We only need to consider the scroll of the default content if the screenshot is a
+    # viewport screenshot. If this is a full page screenshot, the frame location will
+    # not change anyway.
+    if screenshot_type == ScreenshotType.VIEWPORT:
+        location_in_screenshot = location_in_screenshot.offset(
+            -window_scroll.x, -window_scroll.y
+        )
+
+    # For inner frames we must calculate the scroll
+    inner_frames = frame_chain[1:]
+    for frame in inner_frames:
+        location_in_screenshot = location_in_screenshot.offset(
+            frame.location.x - frame.parent_scroll_position.x,
+            frame.location.y - frame.parent_scroll_position.y,
+        )
+    return location_in_screenshot

--- a/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
+++ b/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
@@ -469,13 +469,16 @@ def scroll_root_element_from(driver, container=None):
     return scroll_root_element
 
 
-def current_frame_scroll_root_element(driver):
-    # type: (EyesWebDriver) -> EyesWebElement
+def current_frame_scroll_root_element(driver, scroll_root_element=None):
+    # type: (EyesWebDriver, Optional[AnyWebElement]) -> EyesWebElement
     fc = driver.frame_chain.clone()
     cur_frame = fc.peek
     root_element = None
     if cur_frame:
         root_element = cur_frame.scroll_root_element
     if root_element is None and not driver.is_mobile_app:
-        root_element = driver.find_element_by_tag_name("html")
+        if scroll_root_element:
+            root_element = scroll_root_element
+        else:
+            root_element = driver.find_element_by_tag_name("html")
     return root_element

--- a/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
+++ b/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
@@ -443,6 +443,22 @@ def parse_location_string(position):
     return Point(float(xy[0]), float(xy[1]))
 
 
+def get_current_position(driver, element):
+    # type: (AnyWebDriver, AnyWebElement) -> Point
+    element = get_underlying_webelement(element)
+    xy = driver.execute_script(
+        "return arguments[0].scrollLeft+';'+arguments[0].scrollTop;", element
+    )
+    return parse_location_string(xy)
+
+
+def get_entire_element_size(driver, element):
+    # type: (AnyWebDriver, AnyWebElement) -> RectangleSize
+    element = get_underlying_webelement(element)
+
+    pass
+
+
 def scroll_root_element_from(driver, container=None):
     # type: (EyesWebDriver, Union[SeleniumCheckSettings, FrameLocator]) -> EyesWebElement
     def root_html():

--- a/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
+++ b/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
@@ -487,7 +487,7 @@ def scroll_root_element_from(driver, container=None):
     return scroll_root_element
 
 
-def current_frame_scroll_root_element(driver, scroll_root_element=None):
+def curr_frame_scroll_root_element(driver, scroll_root_element=None):
     # type: (EyesWebDriver, Optional[AnyWebElement]) -> EyesWebElement
     fc = driver.frame_chain.clone()
     cur_frame = fc.peek

--- a/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
+++ b/eyes_selenium/applitools/selenium/eyes_selenium_utils.py
@@ -12,7 +12,8 @@ from selenium.webdriver.remote.webelement import WebElement
 from applitools.common import Point, RectangleSize, logger
 
 if tp.TYPE_CHECKING:
-    from typing import Text, Optional, Any, Iterator, Union
+    from typing import Text, Optional, Any, Union, Generator
+    from applitools.core import PositionProvider
     from applitools.selenium.webdriver import EyesWebDriver
     from applitools.selenium.webelement import EyesWebElement
     from applitools.selenium.fluent import SeleniumCheckSettings, FrameLocator
@@ -371,7 +372,7 @@ def add_data_scroll_to_element(driver, element):
 
 @contextmanager
 def timeout(timeout):
-    # type: (Num) -> Iterator
+    # type: (Num) -> Generator
     time.sleep(timeout)
     yield
 
@@ -452,11 +453,12 @@ def get_current_position(driver, element):
     return parse_location_string(xy)
 
 
-def get_entire_element_size(driver, element):
-    # type: (AnyWebDriver, AnyWebElement) -> RectangleSize
-    element = get_underlying_webelement(element)
-
-    pass
+@contextmanager
+def get_and_restore_state(position_provider):
+    # type: (PositionProvider)-> Generator
+    state = position_provider.get_state()
+    yield state
+    position_provider.restore_state(state)
 
 
 def scroll_root_element_from(driver, container=None):

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -6,7 +6,7 @@ from selenium.common.exceptions import WebDriverException
 
 from applitools.common import EyesError, Point, logger
 from applitools.common.geometry import RectangleSize
-from applitools.core import PositionMomento, PositionProvider
+from applitools.core import PositionMemento, PositionProvider
 
 from . import eyes_selenium_utils
 
@@ -185,7 +185,7 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
             "return arguments[0].style.transform;", self._scroll_root_element
         )
         self._states.append(
-            PositionMomento(position=self._last_set_position, transform=transform)
+            PositionMemento(position=self._last_set_position, transform=transform)
         )
 
     def pop_state(self):

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -158,8 +158,6 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
 
     def get_current_position(self):
         # type: () -> Optional[Point]
-        if self._last_set_position is None:
-            self.set_position(Point.ZERO())
         return self._last_set_position
 
     def set_position(self, location):

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -158,6 +158,8 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
 
     def get_current_position(self):
         # type: () -> Optional[Point]
+        if self._last_set_position is None:
+            self.set_position(Point.ZERO())
         return self._last_set_position
 
     def set_position(self, location):

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -49,7 +49,7 @@ class SeleniumPositionProvider(PositionProvider):
         logger.debug("Creating {}".format(self.__class__.__name__))
 
     def __eq__(self, other):
-        if self.__class__ == other.__class__:
+        if self.__class__ is other.__class__:
             return self._scroll_root_element == other._scroll_root_element
         return False
 
@@ -115,6 +115,7 @@ class ScrollPositionProvider(SeleniumPositionProvider):
 class CSSTranslatePositionProvider(SeleniumPositionProvider):
     def __init__(self, driver, scroll_root_element):
         # type: (EyesWebDriver, AnyWebElement) -> None
+        self._last_set_position = None
         super(CSSTranslatePositionProvider, self).__init__(driver, scroll_root_element)
 
     def get_current_position(self):
@@ -162,7 +163,7 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
             ),
             self._scroll_root_element,
         )
-        self._last_set_position = state.position
+        self._last_set_position = None
 
 
 class ElementPositionProvider(SeleniumPositionProvider):
@@ -181,10 +182,10 @@ class ElementPositionProvider(SeleniumPositionProvider):
     def set_position(self, location):
         # type: (Point) -> Point
         logger.debug("Scrolling element to {}".format(location))
-        self._last_set_position = self._element.scroll_to(location)
+        position = self._element.scroll_to(location)
         logger.debug("Done scrolling element!")
         self._add_data_attribute_to_element()
-        return self._last_set_position
+        return position
 
     def get_entire_size(self):
         try:

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -165,10 +165,11 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
         logger.info(
             "CssTranslatePositionProvider - Setting position to: {}".format(location)
         )
+        negated_location = Point(-location.x, -location.y)
         self._driver.execute_script(
             (
-                "document.documentElement.style.transform='translate(-{:d}px,"
-                "-{:d}px';".format(location["x"], location["y"])
+                "arguments[0].style.transform='translate({:d}px,"
+                "{:d}px';".format(negated_location["x"], negated_location["y"])
             ),
             self._scroll_root_element,
         )

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -109,7 +109,9 @@ return [x, y]"""
             "setting position of %s to %s" % (location, self._scroll_root_element)
         )
         if self._driver.is_mobile_web:
-            scroll_command = "window.scrollTo({0}, {1})".format(location.x, location.y)
+            scroll_command = "window.scrollTo({0}, {1})".format(
+                location["x"], location["y"]
+            )
             self._driver.execute_script(scroll_command)
             self._last_set_position = location
             return self._last_set_position
@@ -117,7 +119,7 @@ return [x, y]"""
             scroll_command = (
                 "arguments[0].scrollLeft=%d; arguments[0].scrollTop=%d; "
                 "return (arguments[0].scrollLeft+';'+arguments["
-                "0].scrollTop);" % (location.x, location.y)
+                "0].scrollTop);" % (location["x"], location["y"])
             )
         self._last_set_position = eyes_selenium_utils.parse_location_string(  # type: ignore
             self._driver.execute_script(scroll_command, self._scroll_root_element)
@@ -166,7 +168,7 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
         self._driver.execute_script(
             (
                 "document.documentElement.style.transform='translate(-{:d}px,"
-                "-{:d}px';".format(location.x, location.y)
+                "-{:d}px';".format(location["x"], location["y"])
             ),
             self._scroll_root_element,
         )

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -131,7 +131,7 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
         logger.info(
             "CssTranslatePositionProvider - Setting position to: {}".format(location)
         )
-        negated_location = Point(-location.x, -location.y)
+        negated_location = -location
         self._driver.execute_script(
             (
                 "arguments[0].style.transform='translate({:d}px,"

--- a/eyes_selenium/applitools/selenium/positioning.py
+++ b/eyes_selenium/applitools/selenium/positioning.py
@@ -180,15 +180,15 @@ class CSSTranslatePositionProvider(SeleniumPositionProvider):
         return self._last_set_position
 
     def push_state(self):
+        # type: () -> PositionMemento
         """
         Adds the transform to the states list.
         """
-        transform = self._driver.execute_script(
+        state = super(CSSTranslatePositionProvider, self).push_state()
+        state.transform = self._driver.execute_script(
             "return arguments[0].style.transform;", self._scroll_root_element
         )
-        self._states.append(
-            PositionMemento(position=self._last_set_position, transform=transform)
-        )
+        return state
 
     def pop_state(self):
         state = self._states.pop()

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -809,14 +809,10 @@ class SeleniumEyes(EyesBase):
         position_provider = None
         if self._target_element and not self.driver.is_mobile_app:
             original_fc = self.driver.frame_chain.clone()
-            switch_to = self.driver.switch_to
             eyes_element = EyesWebElement(element, self.driver)
             element_bounds = eyes_element.bounds
 
             current_frame_offset = original_fc.current_frame_offset
-            element_bounds = element_bounds.offset(
-                current_frame_offset.x, current_frame_offset.y
-            )
             element_bounds = element_bounds.offset(current_frame_offset)
             viewport_bounds = self._get_viewport_scroll_bounds()
             logger.info(
@@ -828,7 +824,7 @@ class SeleniumEyes(EyesBase):
                 self._ensure_frame_visible()
                 element_location = Point.from_(element.location)
                 if len(original_fc) > 0 and element is not original_fc.peek.reference:
-                    switch_to.frames(original_fc)
+                    self.driver.switch_to.frames(original_fc)
                     scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
                         self.driver, self._scroll_root_element
                     )

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -51,7 +51,7 @@ from .positioning import (
     ElementPositionProvider,
     ScrollPositionProvider,
 )
-from .useragent import BrowserNames, UserAgent
+from .useragent import UserAgent
 from .webdriver import EyesWebDriver
 from .webelement import EyesWebElement
 
@@ -62,7 +62,7 @@ if typing.TYPE_CHECKING:
         ViewPort,
         AnyWebElement,
     )
-    from applitools.core import MatchWindowTask, ScaleProvider
+    from applitools.core import MatchWindowTask, ScaleProvider, PositionMemento
     from .frames import Frame
     from .fluent import SeleniumCheckSettings
     from .eyes import Eyes
@@ -97,7 +97,7 @@ class SeleniumEyes(EyesBase):
     _region_position_compensation = None  # type: Optional[RegionPositionCompensation]
     _switched_to_frame_count = 0  # int
     _full_region_to_check = None  # type: Optional[Region]
-
+    _position_memento = None  # type: Optional[PositionMemento]
     current_frame_position_provider = None  # type: Optional[PositionProvider]
 
     @staticmethod

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -733,6 +733,7 @@ class SeleniumEyes(EyesBase):
         #         self._region_to_check.left += int(
         #             self._driver.frame_chain.peek.location.x
         #         )
+
         algo = self._create_full_page_capture_algorithm(scale_provider)
 
         image = algo.get_stitched_region(
@@ -796,7 +797,7 @@ class SeleniumEyes(EyesBase):
         switch_to = self.driver.switch_to
         with switch_to.frames_and_back(self.original_frame_chain):
             try:
-                location = ScrollPositionProvider.get_current_position_static(
+                location = eyes_selenium_utils.get_current_position(
                     self.driver, self.scroll_root_element
                 )
             except WebDriverException as e:

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -826,11 +826,13 @@ class SeleniumEyes(EyesBase):
             if self._check_frame_or_element and not self.driver.is_mobile_app:
                 self._last_screenshot = self._entire_element_screenshot(scale_provider)
             elif (
-                self.configuration.force_full_page_screenshot or self._stitch_content
+                self.configuration.force_full_page_screenshot
+                or self._stitch_content
+                or self._is_check_region
             ) and not self.driver.is_mobile_app:
                 self._last_screenshot = self._full_page_screenshot(scale_provider)
             else:
-                self._last_screenshot = self._viewport_screenshot(scale_provider)
+                self._last_screenshot = self._element_screenshot(scale_provider)
 
         with self._driver.switch_to.frames_and_back(self.original_frame_chain):
             if self.position_provider and not self.driver.is_mobile_platform:
@@ -883,9 +885,9 @@ class SeleniumEyes(EyesBase):
             self._driver, image, original_frame_position
         )
 
-    def _viewport_screenshot(self, scale_provider):
+    def _element_screenshot(self, scale_provider):
         # type: (ScaleProvider) -> EyesWebDriverScreenshot
-        logger.info("Viewport screenshot requested")
+        logger.info("Element screenshot requested")
         with self._ensure_element_visible(self._target_element):
             sleep(self.configuration.wait_before_screenshots / 1000.0)
             image = self._image_provider.get_image()
@@ -906,7 +908,6 @@ class SeleniumEyes(EyesBase):
                 # Some browsers return always full page screenshot (IE).
                 # So we cut such images to viewport size
                 image = cut_to_viewport_size_if_required(self.driver, image)
-
         return EyesWebDriverScreenshot.create_viewport(self._driver, image)
 
     def _get_viewport_scroll_bounds(self):

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -650,7 +650,7 @@ class SeleniumEyes(EyesBase):
         return target_element
 
     def _create_full_page_capture_algorithm(self, scale_provider):
-        scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
+        scroll_root_element = eyes_selenium_utils.curr_frame_scroll_root_element(
             self.driver, self._scroll_root_element
         )
         origin_provider = ScrollPositionProvider(self.driver, scroll_root_element)
@@ -861,7 +861,7 @@ class SeleniumEyes(EyesBase):
     def _check_element(self, name, check_settings):
         element = self._target_element  # type: EyesWebElement
 
-        scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
+        scroll_root_element = eyes_selenium_utils.curr_frame_scroll_root_element(
             self.driver, self._scroll_root_element
         )
         pos_provider = self._create_position_provider(scroll_root_element)

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -263,6 +263,8 @@ class SeleniumEyes(EyesBase):
 
         self._stitch_content = False
         self._scroll_root_element = None
+        if self._position_memento:
+            self._position_provider.restore_state(self._position_memento)
         self._position_provider = None
         self._original_fc = None
         logger.debug("check - done!")

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -649,7 +649,7 @@ class SeleniumEyes(EyesBase):
 
     def _create_full_page_capture_algorithm(self, scale_provider):
         scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
-            self.driver
+            self.driver, self._scroll_root_element
         )
         origin_provider = ScrollPositionProvider(self.driver, scroll_root_element)
         return FullPageCaptureAlgorithm(
@@ -858,7 +858,7 @@ class SeleniumEyes(EyesBase):
         self._full_region_to_check = None
 
         scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
-            self.driver
+            self.driver, self._scroll_root_element
         )
         pos_provider = self._create_position_provider(scroll_root_element)
         result = None

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -35,6 +35,9 @@ from applitools.selenium.capture.full_page_capture_algorithm import (
     FullPageCaptureAlgorithm,
 )
 from applitools.selenium.capture.image_providers import get_image_provider
+from applitools.selenium.capture.screenshot_utils import (
+    cut_to_viewport_size_if_required,
+)
 from applitools.selenium.region_compensation import (
     RegionPositionCompensation,
     get_region_position_compensation,
@@ -902,9 +905,7 @@ class SeleniumEyes(EyesBase):
             if not self._is_check_region and not self._driver.is_mobile_app:
                 # Some browsers return always full page screenshot (IE).
                 # So we cut such images to viewport size
-                image = eyes_selenium_utils.cut_to_viewport_size_if_required(
-                    self.driver, image
-                )
+                image = cut_to_viewport_size_if_required(self.driver, image)
 
         return EyesWebDriverScreenshot.create_viewport(self._driver, image)
 

--- a/eyes_selenium/applitools/selenium/selenium_eyes.py
+++ b/eyes_selenium/applitools/selenium/selenium_eyes.py
@@ -854,13 +854,15 @@ class SeleniumEyes(EyesBase):
 
     def _check_element(self, name, check_settings):
         element = self._target_element  # type: EyesWebElement
-        self._region_to_check = None
-        self._full_region_to_check = None
 
         scroll_root_element = eyes_selenium_utils.current_frame_scroll_root_element(
             self.driver, self._scroll_root_element
         )
         pos_provider = self._create_position_provider(scroll_root_element)
+
+        self._region_to_check = Region.EMPTY()
+        self._full_region_to_check = Region.EMPTY()
+
         result = None
         with pos_provider:
             with self._ensure_element_visible(element):
@@ -870,7 +872,6 @@ class SeleniumEyes(EyesBase):
                     display_style = element.get_computed_style("display")
 
                     if self.configuration.hide_scrollbars:
-                        # FIXME bug if trying to hide
                         element.hide_scrollbars()
 
                     size_and_borders = element.size_and_borders

--- a/eyes_selenium/applitools/selenium/useragent.py
+++ b/eyes_selenium/applitools/selenium/useragent.py
@@ -64,3 +64,4 @@ class OSNames(Enum):
     Macintosh = "Macintosh"
     ChromeOS = "ChromeOS"
     Android = "Android"
+    Linux = "Linux"

--- a/eyes_selenium/applitools/selenium/webdriver.py
+++ b/eyes_selenium/applitools/selenium/webdriver.py
@@ -144,8 +144,10 @@ class _EyesSwitchTo(object):
         for frame in frame_chain:
             self.frame(frame.reference)
             logger.debug(
-                "frame.Reference: %s ; frame.ScrollRootElement: %s"
-                % (frame.reference.id, frame.scroll_root_element.id)
+                "frame.Reference: {}; frame.ScrollRootElement: {}".format(
+                    getattr(frame.reference, "id", None),
+                    getattr(frame.scroll_root_element, "id", None),
+                )
             )
             new_frame = self._driver.frame_chain.peek
             new_frame.scroll_root_element = frame.scroll_root_element

--- a/eyes_selenium/applitools/selenium/webdriver.py
+++ b/eyes_selenium/applitools/selenium/webdriver.py
@@ -93,7 +93,7 @@ class _EyesSwitchTo(object):
         self._switch_to = switch_to  # type: SwitchTo
         self._driver = driver  # type: EyesWebDriver
         self._scroll_position = ScrollPositionProvider(
-            driver, eyes_selenium_utils.current_frame_scroll_root_element(driver)
+            driver, eyes_selenium_utils.curr_frame_scroll_root_element(driver)
         )
 
     @contextlib.contextmanager
@@ -220,9 +220,7 @@ class _EyesSwitchTo(object):
     @contextlib.contextmanager
     def frames_do_scroll(self, frame_chain):
         self.default_content()
-        root_element = eyes_selenium_utils.current_frame_scroll_root_element(
-            self._driver
-        )
+        root_element = eyes_selenium_utils.curr_frame_scroll_root_element(self._driver)
         scroll_provider = ScrollPositionProvider(self._driver, root_element)
         self._position_memento = scroll_provider.get_state()
         for frame in frame_chain:

--- a/eyes_selenium/applitools/selenium/webdriver.py
+++ b/eyes_selenium/applitools/selenium/webdriver.py
@@ -186,23 +186,22 @@ class _EyesSwitchTo(object):
         :param target_frame: The element about to be switched to.
         """
         argument_guard.not_none(target_frame)
-        pl = target_frame.location
 
         size_and_borders = target_frame.size_and_borders
         borders = size_and_borders.borders
         frame_inner_size = size_and_borders.size
+        bounds = target_frame.bounding_client_rect
 
-        content_location = Point(pl["x"] + borders["left"], pl["y"] + borders["top"])
-        sp = ScrollPositionProvider(
-            self._driver, self._driver.find_element_by_tag_name("html")
+        content_location = Point(
+            bounds["x"] + borders["left"], bounds["y"] + borders["top"]
         )
-        original_location = sp.get_current_position()
-        sp.set_position(original_location)
+        original_location = target_frame.scroll_location
+
         frame = Frame(
-            target_frame,
-            content_location,
-            target_frame.size,
-            frame_inner_size,
+            reference=target_frame,
+            location=content_location,
+            outer_size=RectangleSize.from_(target_frame.size),
+            inner_size=RectangleSize.from_(frame_inner_size),
             parent_scroll_position=original_location,
         )
         self._driver.frame_chain.push(frame)

--- a/eyes_selenium/applitools/selenium/webelement.py
+++ b/eyes_selenium/applitools/selenium/webelement.py
@@ -7,7 +7,7 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 
 from applitools.common import logger
-from applitools.common.geometry import Point, Region
+from applitools.common.geometry import CoordinatesType, Point, Region
 from applitools.common.utils.general_utils import proxy_to
 
 from . import eyes_selenium_utils
@@ -163,7 +163,7 @@ class EyesWebElement(object):
             left, width = 0, max(0, width + left)
         if top < 0:
             top, height = 0, max(0, height + top)
-        return Region(left, top, width, height)
+        return Region(left, top, width, height, CoordinatesType.CONTEXT_RELATIVE)
 
     @property
     def location(self):

--- a/eyes_selenium/applitools/selenium/webelement.py
+++ b/eyes_selenium/applitools/selenium/webelement.py
@@ -259,7 +259,7 @@ class EyesWebElement(object):
 
         :return: The previous value of the overflow property (could be None).
         """
-        logger.debug("EyesWebElement.HideScrollbars()")
+        logger.debug("EyesWebElement.hide_scrollbars()")
         self._original_overflow = eyes_selenium_utils.hide_scrollbars(  # type: ignore
             self.driver, self.element
         )
@@ -378,3 +378,6 @@ class SizeAndBorders(object):
     def __init__(self, width, height, left, top, right, bottom):
         self.size = dict(width=width, height=height)
         self.borders = dict(left=left, top=top, right=right, bottom=bottom)
+
+    def __str__(self):
+        return "SizeAndBorders(size={}, borders={})".format(self.size, self.borders)

--- a/eyes_selenium/applitools/selenium/webelement.py
+++ b/eyes_selenium/applitools/selenium/webelement.py
@@ -366,9 +366,10 @@ class EyesWebElement(object):
         )
 
     def __str__(self):
-        return "EyesWebElement: id {}, tag_name {}".format(
-            self._element.id, self._element.tag_name
-        )
+        tag_name = "None"
+        if self.is_attached_to_page:
+            tag_name = self._element.tag_name
+        return "EyesWebElement: id {}, tag_name {}".format(self._element.id, tag_name)
 
 
 class SizeAndBorders(object):

--- a/eyes_selenium/applitools/selenium/webelement.py
+++ b/eyes_selenium/applitools/selenium/webelement.py
@@ -7,7 +7,7 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 
 from applitools.common import logger
-from applitools.common.geometry import Region
+from applitools.common.geometry import Point, Region
 from applitools.common.utils.general_utils import proxy_to
 
 from . import eyes_selenium_utils
@@ -15,7 +15,6 @@ from . import eyes_selenium_utils
 if tp.TYPE_CHECKING:
     from typing import Optional, Text
     from selenium.webdriver.remote.webelement import WebElement
-    from applitools.common.geometry import Point
     from .positioning import SeleniumPositionProvider
     from .webdriver import EyesWebDriver
 
@@ -77,14 +76,36 @@ _JS_GET_SIZE_AND_BORDER_WIDTHS = """
 @proxy_to(
     "_element",
     [
-        "find_element",
-        "find_elements" "tag_name",
+        "tag_name",
         "text",
+        "submit",
+        "clear",
+        "get_property",
+        "get_attribute",
+        "is_selected",
+        "is_enabled",
+        "find_element_by_id",
+        "find_elements_by_id",
+        "find_element_by_name",
+        "find_elements_by_name",
+        "find_element_by_link_text",
+        "find_elements_by_link_text",
+        "find_element_by_partial_link_text",
+        "find_elements_by_partial_link_text",
+        "find_element_by_tag_name",
+        "find_elements_by_tag_name",
+        "find_element_by_xpath",
+        "find_elements_by_xpath",
+        "find_element_by_class_name",
+        "find_elements_by_class_name",
+        "find_element_by_css_selector",
+        "find_elements_by_css_selector",
+        "is_displayed",
         "location_once_scrolled_into_view",
         "parent",
-        "rect",
         "screenshot_as_base64",
         "screenshot_as_png",
+        "screenshot",
         "location_in_view",
         "anonymous_children",
     ],
@@ -149,6 +170,10 @@ class EyesWebElement(object):
         return self._element.location
 
     @property
+    def rect(self):
+        return self._element.rect
+
+    @property
     def is_attached_to_page(self):
         try:
             self.location
@@ -204,7 +229,7 @@ class EyesWebElement(object):
         """
         Clicks and element.
         """
-        self._driver._eyes.add_mouse_trigger_by_element("click", self)
+        self._driver.eyes.add_mouse_trigger_by_element("click", self)
         self._element.click()
 
     def send_keys(self, *value):
@@ -299,7 +324,7 @@ class EyesWebElement(object):
         # type: (Point) -> Point
         """Scrolls to the specified location inside the element."""
         position = self._driver.execute_script(
-            _JS_SCROLL_TO_FORMATTED_STR.format(location.x, location.y)
+            _JS_SCROLL_TO_FORMATTED_STR.format(location["x"], location["y"])
             + _JS_GET_SCROLL_POSITION,
             self._element,
         )
@@ -318,6 +343,20 @@ class EyesWebElement(object):
             top=int(ret_val[3].rstrip("px")),
             right=int(ret_val[4].rstrip("px")),
             bottom=int(ret_val[5].rstrip("px")),
+        )
+
+    @property
+    def bounding_client_rect(self):
+        left, top, width, height = self.driver.execute_script(
+            "var r = arguments[0].getBoundingClientRect();"
+            "return r.left+';'+r.top+';'+r.width+';'+r.height;",
+            self._element,
+        ).split(";")
+        return dict(
+            x=math.ceil(float(left)),
+            y=math.ceil(float(top)),
+            width=math.ceil(float(width)),
+            height=math.ceil(float(height)),
         )
 
     def __str__(self):

--- a/eyes_selenium/applitools/selenium/webelement.py
+++ b/eyes_selenium/applitools/selenium/webelement.py
@@ -186,6 +186,12 @@ class EyesWebElement(object):
         return self._element.size
 
     @property
+    def scroll_location(self):
+        # type: () -> Point
+        pos = self.driver.execute_script(_JS_GET_SCROLL_POSITION, self.element)
+        return eyes_selenium_utils.parse_location_string(pos)
+
+    @property
     def id(self):
         return self._element.id
 

--- a/tasks.py
+++ b/tasks.py
@@ -165,7 +165,7 @@ def run_selenium_tests(c, remote=False, headless=False, platform=None):
         "--browser '%(browser)s' {tests} "
         "--ignore={tests}/test_client_sites.py"
     ).format(
-        proc_num="-n 2" if remote else "",
+        proc_num="-n 4" if remote else "",
         headless=headless,
         remote="--remote 1" if remote else "",
         platform=platform,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,10 @@ SUPPORTED_PLATFORMS = [
         name="Windows",
         version="10",
         browsers=COMMON_BROWSERS
-        + [("internet explorer", "latest"), ("MicrosoftEdge", "latest")],
+        + [
+            ("internet explorer", "latest"),
+            # ("MicrosoftEdge", "latest")
+        ],
         extra=None,
     ),
     Platform(name="Linux", version="", browsers=COMMON_BROWSERS, extra=None),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 from itertools import chain
 
 import pytest
-
 from common_fixtures import *  # noqa
 
 try:
@@ -193,7 +192,7 @@ def _setup_env_vars_for_session():
 
 def pytest_generate_tests(metafunc):
     platform_name = metafunc.config.getoption("platform")
-    browser_name = metafunc.config.getoption("browser")
+    browser_name = metafunc.config.getoption("browser", "chrome")
     headless = metafunc.config.getoption("headless")
 
     _setup_env_vars_for_session()

--- a/tests/functional/eyes_images/conftest.py
+++ b/tests/functional/eyes_images/conftest.py
@@ -11,7 +11,7 @@ def eyes_class():
 
 
 def _setup_env_vars_for_session():
-    os.environ["APPLITOOLS_BATCH_NAME"] = "Python | Images SDK {}".format(__version__)
+    os.environ["APPLITOOLS_BATCH_NAME"] = "Py|Img|{}".format(__version__)
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/functional/eyes_selenium/conftest.py
+++ b/tests/functional/eyes_selenium/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import typing
 
 from selenium import webdriver
@@ -27,7 +28,7 @@ BROWSERS_WEBDRIVERS = {
 
 
 def _setup_env_vars_for_session():
-    os.environ["APPLITOOLS_BATCH_NAME"] = "Python | Selenium SDK {}".format(__version__)
+    os.environ["APPLITOOLS_BATCH_NAME"] = "Py|Sel|{}".format(__version__)
 
 
 def pytest_generate_tests(metafunc):
@@ -63,6 +64,13 @@ def eyes_open(request, eyes, driver):
     test_name = request.function.__name__.title().replace("_", "")
     test_name = test_name.replace(test_name_pattern["from"], test_name_pattern["to"])
 
+    batch_name = os.getenv("APPLITOOLS_BATCH_NAME")
+    eyes.configuration.batch = BatchInfo(
+        "{}|{}".format(
+            batch_name,
+            driver.desired_capabilities.get("platformName", sys.platform.capitalize()),
+        )
+    )
     if eyes.force_full_page_screenshot:
         test_suite_name += " - ForceFPS"
         test_name += "_FPS"

--- a/tests/functional/eyes_selenium/conftest.py
+++ b/tests/functional/eyes_selenium/conftest.py
@@ -66,10 +66,12 @@ def eyes_open(request, eyes, driver):
     if eyes.force_full_page_screenshot:
         test_suite_name += " - ForceFPS"
         test_name += "_FPS"
-    driver = eyes.open(driver, test_suite_name, test_name, viewport_size=viewport_size)
-    driver.get(test_page_url)
+    eyes_driver = eyes.open(
+        driver, test_suite_name, test_name, viewport_size=viewport_size
+    )
+    eyes_driver.get(test_page_url)
 
-    yield eyes, driver
+    yield eyes, eyes_driver
     results = eyes.close()
     print(results)
 

--- a/tests/functional/eyes_selenium/selenium/test_client_sites.py
+++ b/tests/functional/eyes_selenium/selenium/test_client_sites.py
@@ -4,7 +4,8 @@ import pytest
 from applitools.selenium import StitchMode, Target
 
 
-@pytest.mark.skip("Depending on Fluent API. Not implemented yet")
+@pytest.mark.platform("Linux")
+@pytest.mark.skip
 def test_wix_site(eyes, driver):
     eyes.match_timeout = 0
     eyes.force_full_page_screenshot = False
@@ -14,14 +15,14 @@ def test_wix_site(eyes, driver):
         "https://eventstest.wixsite.com/events-page-e2e/events/ba837913-7dad-41b9-b530-6c2cbfc4c265"
     )
     iframe_id = "TPAMultiSection_j5ocg4p8iframe"
-    driver.switch_to().frame(iframe_id)
+    driver.switch_to.frame(iframe_id)
     # click register button
-    driver.find_element(By.CSS_SELECTOR, "[data-hook=get-tickets-button]").click()
+    driver.find_element_by_css_selector("[data-hook=get-tickets-button]").click()
     # add one ticket
-    driver.find_element(By.CSS_SELECTOR, "[data-hook=plus-button]").click()
+    driver.find_element_by_css_selector("[data-hook=plus-button]").click()
     # just an example, where it make us some problems with scrolling to top of the frame.
     # eyes.check_region(By.CSS_SELECTOR, "[data-hook=plus-button]");
-    eyes.check("", Target.region([By.CSS_SELECTOR, "[data-hook=plus-button]"]))
+    eyes.check("", Target.region("[data-hook=plus-button]"))
     eyes.close()
 
 
@@ -35,7 +36,9 @@ def test_w3schools_iframe(eyes, driver):
         viewport_size={"width": 800, "height": 600},
     )
     driver.get("https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe")
-    eyes.check("Entire Frame", Target.region((By.TAG_NAME, "body"), "iframeResult"))
+    eyes.check(
+        "Entire Frame", Target.frame("iframeResult").region([By.TAG_NAME, "body"])
+    )
     eyes.close()
 
 
@@ -85,6 +88,7 @@ def test_zachs_app(eyes, driver):
     eyes.close()
 
 
+@pytest.mark.platform("Linux")
 @pytest.mark.eyes(
     hide_scrollbars=True, stitch_mode=StitchMode.Scroll, wait_before_screenshots=1
 )

--- a/tests/functional/eyes_selenium/selenium/test_dom_capture.py
+++ b/tests/functional/eyes_selenium/selenium/test_dom_capture.py
@@ -3,12 +3,12 @@ import os
 import time
 from collections import OrderedDict
 
-import pytest
 from selenium.webdriver.common.by import By
 
+import pytest
 from applitools.common import Point
+from applitools.selenium import eyes_selenium_utils
 from applitools.selenium.capture import dom_capture
-from applitools.selenium.positioning import ScrollPositionProvider
 
 
 @pytest.mark.usefixtures("driver_for_class")
@@ -126,7 +126,7 @@ class TestDomCaptureUnit(object):
     def test_position_scrolled_to_origin_after_traversing(self):
         # Page must contain scrolling
         dom_json = dom_capture.get_full_window_dom(self.driver)  # noqa: F841
-        current_scroll = ScrollPositionProvider.get_current_position_static(
+        current_scroll = eyes_selenium_utils.get_current_position(
             self.driver, self.driver.find_element_by_tag_name("html")
         )
         assert current_scroll == Point(0, 0)

--- a/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
+++ b/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
@@ -8,6 +8,7 @@ from applitools.selenium import Region, StitchMode, Target
 @pytest.mark.platform("Linux", "Windows", "macOS")
 @pytest.mark.usefixtures("eyes_for_class")
 @pytest.mark.viewport_size({"width": 700, "height": 460})
+# @pytest.mark.viewport_size({"width": 800, "height": 600})
 @pytest.mark.eyes(stitch_mode=StitchMode.CSS)
 class TestSetup(object):
     pass
@@ -52,7 +53,6 @@ class TestFluentAPI(TestSetup):
             .ignore(Region(left=50, top=50, width=100, height=100)),
         )
 
-    #
     def test_check_region_with_ignore_region_fluent(self):
         self.eyes.check(
             "Fluent - Region with Ignore region",
@@ -61,6 +61,75 @@ class TestFluentAPI(TestSetup):
             ),
         )
 
+    def test_scrollbars_hidden_and_returned_fluent(self):
+        self.eyes.check("Fluent - Window (Before)", Target.window().fully())
+        self.eyes.check(
+            "Fluent - Inner frame div",
+            Target.frame("frame1").region("#inner-frame-div").fully(),
+        )
+        self.eyes.check("Fluent - Window (After)", Target.window().fully())
+
+    def test_check_window_with_ignore_by_selector_fluent(self):
+        self.eyes.check(
+            "Fluent - Window with ignore region by selector",
+            Target.window().ignore("#overflowing-div"),
+        )
+
+    def test_check_window_with_floating_by_selector_fluent(self):
+        self.eyes.check(
+            "Fluent - Window with floating region by selector",
+            Target.window().floating("#overflowing-div", 3, 3, 20, 30),
+        )
+
+    def test_check_window_with_floating_by_region_fluent(self):
+        self.eyes.check(
+            "Fluent - Window with floating region by selector",
+            Target.window().floating(Region(10, 10, 10, 10), 3, 3, 20, 30),
+        )
+
+    def test_check_element_fully_fluent(self):
+        element = self.driver.find_element_by_css_selector("#overflowing-div-image")
+        self.eyes.check(
+            "Fluent - Region by element - fully", Target.region(element).fully()
+        )
+
+    def test_check_element_with_ignore_region_by_element_fluent(self):
+        element = self.driver.find_element_by_id("overflowing-div-image")
+        ignore_element = self.driver.find_element_by_id("overflowing-div")
+        self.eyes.check(
+            "Fluent - Region by element - fully",
+            Target.region(element).ignore(ignore_element),
+        )
+
+    def test_check_element_fluent(self):
+        element = self.driver.find_element(By.ID, "overflowing-div-image")
+        self.eyes.check("Fluent - Region by element - fully", Target.region(element))
+
+    def test_check_element_with_ignore_region_by_element_outside_the_viewport_fluent(
+        self
+    ):
+        element = self.driver.find_element_by_id("overflowing-div-image")
+        ignore_element = self.driver.find_element_by_id("overflowing-div")
+        self.eyes.check(
+            "Fluent - Region by element", Target.region(element).ignore(ignore_element)
+        )
+
+    def test_check_element_with_ignore_region_by_same_element_fluent(self):
+        element = self.driver.find_element_by_id("overflowing-div-image")
+        self.eyes.check(
+            "Fluent - Region by element", Target.region(element).ignore(element)
+        )
+
+    def test_check_full_window_with_multiple_ignore_regions_by_selector_fluent(self):
+        self.eyes.check(
+            "Fluent - Region by element", Target.window().fully().ignore(".ignore")
+        )
+
+
+@pytest.mark.test_suite_name("Eyes Selenium SDK - Fluent API")
+@pytest.mark.test_page_url("http://applitools.github.io/demo/TestPages/FramesTestPage/")
+@pytest.mark.test_name_pattern({"from": "Fluent", "to": "_Fluent"})
+class TestFluentAPIFrames(TestSetup):
     def test_check_frame_fully_fluent(self):
         self.eyes.check("Fluent - Full Frame", Target.frame("frame1").fully())
 
@@ -79,14 +148,6 @@ class TestFluentAPI(TestSetup):
             "Fluent - Region in Frame in Frame",
             Target.frame("frame1").region([By.ID, "inner-frame-div"]).fully(),
         )
-
-    def test_scrollbars_hidden_and_returned_fluent(self):
-        self.eyes.check("Fluent - Window (Before)", Target.window().fully())
-        self.eyes.check(
-            "Fluent - Inner frame div",
-            Target.frame("frame1").region("#inner-frame-div").fully(),
-        )
-        self.eyes.check("Fluent - Window (After)", Target.window().fully())
 
     def test_check_region_in_frame2_fluent(self):
         self.eyes.check(
@@ -125,10 +186,13 @@ class TestFluentAPI(TestSetup):
             .floating(25, Region(200, 200, 150, 150)),
         )
 
-    def test_check_region_by_coordinate_in_frame_fluent(self):
+    def test_check_region_in_frame3_fluent(self):
         self.eyes.check(
-            "Fluent - Inner frame coordinates",
-            Target.frame("frame1").region(Region(30, 40, 400, 1200)),
+            "Fluent - Full frame with floating region",
+            Target.frame("frame1")
+            .fully()
+            .layout()
+            .floating(25, Region(200, 200, 150, 150)),
         )
 
     def test_check_region_by_coordinate_in_frame_fully_fluent(self):
@@ -137,67 +201,17 @@ class TestFluentAPI(TestSetup):
             Target.frame("frame1").region(Region(30, 40, 400, 1200)).fully(),
         )
 
+    def test_check_region_by_coordinate_in_frame_fluent(self):
+        self.eyes.check(
+            "Fluent - Inner frame coordinates",
+            Target.frame("frame1").region(Region(30, 40, 400, 1200)),
+        )
+
     def test_check_frame_in_frame_fully_fluent2(self):
         self.eyes.check("Fluent - Window", Target.window().fully())
         self.eyes.check(
             "Fluent - Full Frame in Frame 2",
             Target.frame("frame1").frame("frame1-1").fully(),
-        )
-
-    def test_check_window_with_ignore_by_selector_fluent(self):
-        self.eyes.check(
-            "Fluent - Window with ignore region by selector",
-            Target.window().ignore("#overflowing-div"),
-        )
-
-    def test_check_window_with_floating_by_selector_fluent(self):
-        self.eyes.check(
-            "Fluent - Window with floating region by selector",
-            Target.window().floating("#overflowing-div", 3, 3, 20, 30),
-        )
-
-    def test_check_window_with_floating_by_region_fluent(self):
-        self.eyes.check(
-            "Fluent - Window with floating region by selector",
-            Target.window().floating(Region(10, 10, 10, 10), 3, 3, 20, 30),
-        )
-
-    def test_check_element_fully_fluent(self):
-        element = self.driver.find_element_by_css_selector("#overflowing-div-image")
-        self.eyes.check(
-            "Fluent - Region by element - fully", Target.region(element).fully()
-        )
-
-    def test_check_element_with_ignore_region_by_element_fluent(self):
-        element = self.driver.find_element_by_id("overflowing-div-image")
-        ignore_element = self.driver.find_element_by_id("overflowing-div")
-        self.eyes.check(
-            "Fluent - Region by element - fully",
-            Target.region(element).ignore(ignore_element),
-        )
-
-    def test_check_element_fluent_fully(self):
-        element = self.driver.find_element(By.ID, "overflowing-div-image")
-        self.eyes.check("Fluent - Region by element - fully", Target.region(element))
-
-    def test_check_element_with_ignore_region_by_element_outside_the_viewport_fluent(
-        self
-    ):
-        element = self.driver.find_element_by_id("overflowing-div-image")
-        ignore_element = self.driver.find_element_by_id("overflowing-div")
-        self.eyes.check(
-            "Fluent - Region by element", Target.region(element).ignore(ignore_element)
-        )
-
-    def test_check_element_with_ignore_region_by_same_element_fluent(self):
-        element = self.driver.find_element_by_id("overflowing-div-image")
-        self.eyes.check(
-            "Fluent - Region by element", Target.region(element).ignore(element)
-        )
-
-    def test_check_full_window_with_multiple_ignore_regions_by_selector_fluent(self):
-        self.eyes.check(
-            "Fluent - Region by element", Target.window().fully().ignore(".ignore")
         )
 
 
@@ -210,9 +224,10 @@ class TestSpecialCases(TestSetup):
         self.eyes.check("map", Target.frame("frame1").region([By.TAG_NAME, "img"]))
 
     def test_check_region_in_a_very_big_frame_after_manual_switch_frame(self):
-        with self.driver.switch_to.frame_and_back("frame1"):
-            element = self.driver.find_element(By.CSS_SELECTOR, "img")
-            self.driver.execute_script(
-                "arguments[0].scrollIntoView(true);", element.element
-            )
-            self.eyes.check("", Target.region([By.CSS_SELECTOR, "img"]))
+        self.driver.switch_to.frame("frame1")
+
+        element = self.driver.find_element(By.CSS_SELECTOR, "img")
+        self.driver.execute_script(
+            "arguments[0].scrollIntoView(true);", element.element
+        )
+        self.eyes.check("", Target.region([By.CSS_SELECTOR, "img"]))

--- a/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
+++ b/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
@@ -202,6 +202,7 @@ class TestFluentAPIFrames(TestSetup):
         )
 
     def test_check_region_by_coordinate_in_frame_fluent(self):
+        self.eyes.hide_scrollbars = False
         self.eyes.check(
             "Fluent - Inner frame coordinates",
             Target.frame("frame1").region(Region(30, 40, 400, 1200)),

--- a/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
+++ b/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
@@ -215,12 +215,18 @@ class TestFluentAPIFrames(TestSetup):
             Target.frame("frame1").frame("frame1-1").fully(),
         )
 
+    def test_manual_switch_frame(self):
+        self.driver.switch_to.frame("frame1")
+        self.eyes.check("", Target.region("#inner-frame-div"))
+
 
 @pytest.mark.test_suite_name("Eyes Selenium SDK - Special Cases")
 @pytest.mark.test_page_url(
     "http://applitools.github.io/demo/TestPages/WixLikeTestPage/index.html"
 )
+@pytest.mark.skip("Knowing issue")
 class TestSpecialCases(TestSetup):
+    # TODO: Fix tests
     def test_check_region_in_a_very_big_frame(self):
         self.eyes.check("map", Target.frame("frame1").region([By.TAG_NAME, "img"]))
 

--- a/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
+++ b/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
@@ -64,11 +64,10 @@ class TestFluentAPI(TestSetup):
     def test_check_frame_fully_fluent(self):
         self.eyes.check("Fluent - Full Frame", Target.frame("frame1").fully())
 
-    @pytest.mark.skip("FIXME Wrong baseline")
     def test_check_frame_fluent(self):
+        self.eyes.hide_scrollbars = False
         self.eyes.check("Fluent - Frame", Target.frame("frame1"))
 
-    @pytest.mark.skip("FIXME Wrong baseline")
     def test_check_frame_in_frame_fully_fluent(self):
         self.eyes.check(
             "Fluent - Full Frame in Frame",
@@ -89,7 +88,6 @@ class TestFluentAPI(TestSetup):
         )
         self.eyes.check("Fluent - Window (After)", Target.window().fully())
 
-    @pytest.mark.skip("FIXME Known issue. Issue with restoring position state")
     def test_check_region_in_frame2_fluent(self):
         self.eyes.check(
             "Fluent - Inner frame div 1",
@@ -130,12 +128,15 @@ class TestFluentAPI(TestSetup):
     def test_check_region_by_coordinate_in_frame_fluent(self):
         self.eyes.check(
             "Fluent - Inner frame coordinates",
-            Target.frame("frame1")
-            .region(Region(30, 40, 400, 1200, CoordinatesType.CONTEXT_RELATIVE))
-            .fully(),
+            Target.frame("frame1").region(Region(30, 40, 400, 1200)),
         )
 
-    @pytest.mark.skip("FIXME Wrong baseline")
+    def test_check_region_by_coordinate_in_frame_fully_fluent(self):
+        self.eyes.check(
+            "Fluent - Inner frame coordinates",
+            Target.frame("frame1").region(Region(30, 40, 400, 1200)).fully(),
+        )
+
     def test_check_frame_in_frame_fully_fluent2(self):
         self.eyes.check("Fluent - Window", Target.window().fully())
         self.eyes.check(
@@ -206,7 +207,6 @@ class TestFluentAPI(TestSetup):
 )
 class TestSpecialCases(TestSetup):
     def test_check_region_in_a_very_big_frame(self):
-        self.eyes.is_debug_screenshot_provided = True
         self.eyes.check("map", Target.frame("frame1").region([By.TAG_NAME, "img"]))
 
     def test_check_region_in_a_very_big_frame_after_manual_switch_frame(self):

--- a/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
+++ b/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
@@ -9,11 +9,11 @@ from applitools.selenium import Region, StitchMode, Target
 @pytest.mark.usefixtures("eyes_for_class")
 @pytest.mark.viewport_size({"width": 700, "height": 460})
 @pytest.mark.eyes(stitch_mode=StitchMode.CSS)
-@pytest.mark.test_page_url("http://applitools.github.io/demo/TestPages/FramesTestPage/")
 class TestSetup(object):
     pass
 
 
+@pytest.mark.test_page_url("http://applitools.github.io/demo/TestPages/FramesTestPage/")
 @pytest.mark.test_suite_name("Eyes Selenium SDK - Classic API")
 class TestClassicAPI(TestSetup):
     def test_check_window(self):
@@ -39,6 +39,7 @@ class TestClassicAPI(TestSetup):
 
 
 @pytest.mark.test_suite_name("Eyes Selenium SDK - Fluent API")
+@pytest.mark.test_page_url("http://applitools.github.io/demo/TestPages/FramesTestPage/")
 @pytest.mark.test_name_pattern({"from": "Fluent", "to": "_Fluent"})
 class TestFluentAPI(TestSetup):
     def test_check_window_with_ignore_region_fluent(self):
@@ -203,16 +204,15 @@ class TestFluentAPI(TestSetup):
 @pytest.mark.test_page_url(
     "http://applitools.github.io/demo/TestPages/WixLikeTestPage/index.html"
 )
-@pytest.mark.skip("FIXME Failing")
 class TestSpecialCases(TestSetup):
     def test_check_region_in_a_very_big_frame(self):
-        self.eyes.check("map", Target.frame("frame1").region((By.TAG_NAME, "img")))
+        self.eyes.is_debug_screenshot_provided = True
+        self.eyes.check("map", Target.frame("frame1").region([By.TAG_NAME, "img"]))
 
     def test_check_region_in_a_very_big_frame_after_manual_switch_frame(self):
         with self.driver.switch_to.frame_and_back("frame1"):
             element = self.driver.find_element(By.CSS_SELECTOR, "img")
-            # TODO #112: fix bug execute_script method calling with EyesWebElement
             self.driver.execute_script(
                 "arguments[0].scrollIntoView(true);", element.element
             )
-            self.eyes.check("", Target.region((By.CSS_SELECTOR, "img")))
+            self.eyes.check("", Target.region([By.CSS_SELECTOR, "img"]))

--- a/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
+++ b/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
@@ -1,13 +1,13 @@
-import pytest
 from selenium.webdriver.common.by import By
 
+import pytest
 from applitools.common import CoordinatesType
 from applitools.selenium import Region, StitchMode, Target
 
 
 @pytest.mark.platform("Linux", "Windows", "macOS")
 @pytest.mark.usefixtures("eyes_for_class")
-@pytest.mark.viewport_size({"width": 800, "height": 600})
+@pytest.mark.viewport_size({"width": 700, "height": 460})
 @pytest.mark.eyes(stitch_mode=StitchMode.CSS)
 @pytest.mark.test_page_url("http://applitools.github.io/demo/TestPages/FramesTestPage/")
 class TestSetup(object):

--- a/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
+++ b/tests/functional/eyes_selenium/selenium/test_main_use_flows.py
@@ -224,9 +224,7 @@ class TestFluentAPIFrames(TestSetup):
 @pytest.mark.test_page_url(
     "http://applitools.github.io/demo/TestPages/WixLikeTestPage/index.html"
 )
-@pytest.mark.skip("Knowing issue")
 class TestSpecialCases(TestSetup):
-    # TODO: Fix tests
     def test_check_region_in_a_very_big_frame(self):
         self.eyes.check("map", Target.frame("frame1").region([By.TAG_NAME, "img"]))
 

--- a/tests/functional/eyes_selenium/selenium/test_specific_cases.py
+++ b/tests/functional/eyes_selenium/selenium/test_specific_cases.py
@@ -58,3 +58,24 @@ def test_abort_eyes(eyes, driver):
     eyes.open(driver, "Python | VisualGrid", "TestAbortSeleniumEyes")
     eyes.check_window()
     eyes.abort()
+
+
+@pytest.mark.platform("Linux")
+def test_coordinates_resolving(eyes, driver):
+    driver.get("https://applitools.com/helloworld")
+    driver = eyes.open(
+        driver,
+        "Python Selenium",
+        "TestCoordinatesResolving",
+        {"width": 800, "height": 600},
+    )
+    element = driver.find_element_by_css_selector("button")
+    left = element.location["x"]
+    top = element.location["y"]
+    width = element.size["width"]
+    height = element.size["height"]
+
+    eyes.check("web element", Target.region(element))
+    eyes.check("coordinates", Target.region(Region(left, top, width, height)))
+
+    eyes.close()

--- a/tests/functional/eyes_selenium/visual_grid/test_top_clients.py
+++ b/tests/functional/eyes_selenium/visual_grid/test_top_clients.py
@@ -14,7 +14,7 @@ def sel_config(test_page_url):
     conf = Configuration()
     conf.test_name = "Top 10 websites - {}".format(test_page_url)
     conf.app_name = "Top Ten Sites"
-    conf.batch = BatchInfo("Python | VisualGrid")
+    conf.batch = BatchInfo("Py|VG")
     conf.branch_name = "TTS - config branch"
     conf.add_browser(800, 600, BrowserType.CHROME)
     conf.add_browser(700, 500, BrowserType.FIREFOX)


### PR DESCRIPTION
Bugfix wrong element coordinates
https://trello.com/c/2Cg1DIW8/769-python-version-4-check-element-captures-the-wrong-element-coordinates?menu=filter&filter=due:notdue

Wrong coordinates when capturing region and element where DPI is different from 1
https://trello.com/c/aYyUTINc/781-wrong-coordinates-when-capturing-region-and-element-where-dpi-is-different-from-1

Blank lines when capturing on Android
https://trello.com/c/e6hR8Nmt/493-blank-lines-when-capturing-on-android

Fix custom frame swtiching outside fluent interface

Python 4.x - IE 11 always full page screenshots
https://trello.com/c/YqLskoE9/876-python-4x-ie-11-always-full-page-screenshots

