### PR TITLE
Bugfix Trello 1566 VG tests hang intermittently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Fixed
+- VG tests hang intermittently [Trello 1566](https://trello.com/c/kU2EaDiE)
+
 # [4.1.22] - 2020-03-18
 ## Fixed
 - Issue With VG Capturing After Element Check [Trello 1639](https://trello.com/c/tPRpKuOX)

--- a/eyes_common/applitools/common/utils/__init__.py
+++ b/eyes_common/applitools/common/utils/__init__.py
@@ -22,7 +22,7 @@ from .url_utils import apply_base_url, is_url_with_scheme, is_absolute_url  # no
 
 
 __all__ = (
-    compat.__all__
-    + url_utils.__all__
+    compat.__all__  # noqa
+    + url_utils.__all__  # noqa
     + ("image_utils", "argument_guard", "datetime_utils")
-)  # noqa
+)

--- a/eyes_common/applitools/common/utils/__init__.py
+++ b/eyes_common/applitools/common/utils/__init__.py
@@ -18,5 +18,11 @@ from .datetime_utils import (  # type: ignore # noqa
     to_rfc1123_datetime,
 )
 from .general_utils import cached_property  # noqa
+from .url_utils import apply_base_url, is_url_with_scheme, is_absolute_url  # noqa
 
-__all__ = compat.__all__ + ("image_utils", "argument_guard", "datetime_utils")  # noqa
+
+__all__ = (
+    compat.__all__
+    + url_utils.__all__
+    + ("image_utils", "argument_guard", "datetime_utils")
+)  # noqa

--- a/eyes_common/applitools/common/utils/__init__.py
+++ b/eyes_common/applitools/common/utils/__init__.py
@@ -17,12 +17,12 @@ from .datetime_utils import (  # type: ignore # noqa
     current_time_in_rfc1123,
     to_rfc1123_datetime,
 )
-from .general_utils import cached_property  # noqa
+from .general_utils import cached_property, counted  # noqa
 from .url_utils import apply_base_url, is_url_with_scheme, is_absolute_url  # noqa
 
 
 __all__ = (
     compat.__all__  # noqa
     + url_utils.__all__  # noqa
-    + ("image_utils", "argument_guard", "datetime_utils")
+    + ("image_utils", "argument_guard", "datetime_utils", "counted")
 )

--- a/eyes_common/applitools/common/utils/datetime_utils.py
+++ b/eyes_common/applitools/common/utils/datetime_utils.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import itertools
 import time
 from datetime import datetime, timedelta, tzinfo

--- a/eyes_common/applitools/common/utils/datetime_utils.py
+++ b/eyes_common/applitools/common/utils/datetime_utils.py
@@ -89,7 +89,7 @@ def sleep(time_ms, msg=None, verbose=True):
     """
     time.sleep(to_sec(time_ms))
     if verbose:
-        logger.debug("Sleep for {} ms | {}".format(time_ms, msg if msg else ""))
+        logger.debug("Sleep for {} ms {}".format(time_ms, msg if msg else ""))
 
 
 def timeit(method):

--- a/eyes_common/applitools/common/utils/datetime_utils.py
+++ b/eyes_common/applitools/common/utils/datetime_utils.py
@@ -89,7 +89,7 @@ def sleep(time_ms, msg=None, verbose=True):
     """
     time.sleep(to_sec(time_ms))
     if verbose:
-        logger.debug("Sleep for {} ms {}".format(time_ms, msg if msg else ""))
+        logger.debug("Sleep for {} ms | {}".format(time_ms, msg if msg else ""))
 
 
 def timeit(method):

--- a/eyes_common/applitools/common/utils/datetime_utils.py
+++ b/eyes_common/applitools/common/utils/datetime_utils.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import itertools
 import time
 from datetime import datetime, timedelta, tzinfo

--- a/eyes_common/applitools/common/utils/general_utils.py
+++ b/eyes_common/applitools/common/utils/general_utils.py
@@ -7,7 +7,7 @@ import typing
 
 import attr
 
-from .compat import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
+from .compat import parse_qs, urlencode, urlsplit, urlunsplit
 
 """
 General purpose utilities.
@@ -48,14 +48,6 @@ def cached_property(f):
             return x
 
     return property(get)
-
-
-def is_absolute_url(url):
-    return bool(urlparse(url).netloc)
-
-
-def is_url_with_scheme(url):
-    return bool(urlparse(url).scheme)
 
 
 def get_sha256_hash(content):

--- a/eyes_common/applitools/common/utils/general_utils.py
+++ b/eyes_common/applitools/common/utils/general_utils.py
@@ -137,3 +137,16 @@ def get_env_with_prefix(env_name, default=None):
             if value:
                 return value
     return default
+
+
+def counted(f):
+    """
+    Decorator that tracks how many times the function is called
+    """
+
+    def wrapped(*args, **kwargs):
+        wrapped.calls += 1
+        return f(*args, **kwargs)
+
+    wrapped.calls = 0
+    return wrapped

--- a/eyes_common/applitools/common/utils/url_utils.py
+++ b/eyes_common/applitools/common/utils/url_utils.py
@@ -11,10 +11,10 @@ def is_url_with_scheme(url):
     return bool(urlparse(url).scheme)
 
 
-def apply_base_url(discovered_url, base_url, resource_url=None):
+def apply_base_url(discovered_url, site_base_url, resource_url=None):
     url = urlparse(discovered_url)
     if url.scheme in ["http", "https"] and url.netloc:
         return discovered_url
-    if resource_url:
-        base_url = resource_url
-    return urljoin(base_url, discovered_url)
+    if resource_url and is_url_with_scheme(resource_url):
+        site_base_url = resource_url
+    return urljoin(site_base_url, discovered_url)

--- a/eyes_common/applitools/common/utils/url_utils.py
+++ b/eyes_common/applitools/common/utils/url_utils.py
@@ -1,0 +1,20 @@
+from .compat import urlparse, urljoin
+
+__all__ = ("apply_base_url", "is_url_with_scheme", "is_absolute_url")
+
+
+def is_absolute_url(url):
+    return bool(urlparse(url).netloc)
+
+
+def is_url_with_scheme(url):
+    return bool(urlparse(url).scheme)
+
+
+def apply_base_url(discovered_url, base_url, resource_url=None):
+    url = urlparse(discovered_url)
+    if url.scheme in ["http", "https"] and url.netloc:
+        return discovered_url
+    if resource_url:
+        base_url = resource_url
+    return urljoin(base_url, discovered_url)

--- a/eyes_core/applitools/core/server_connector.py
+++ b/eyes_core/applitools/core/server_connector.py
@@ -537,11 +537,9 @@ class ServerConnector(object):
             headers["User-Agent"] = self._ua_string
         logger.debug("Fetching URL {}\nwith headers {}".format(url, headers))
         timeout_sec = datetime_utils.to_sec(self._com.timeout_ms)
-        response = self.client_session.get(
-            url, headers=headers, timeout=timeout_sec, verify=False
-        )
+        response = requests.get(url, headers=headers, timeout=timeout_sec, verify=False)
         if response.status_code == requests.codes.not_acceptable:
-            response = self.client_session.get(url, timeout=timeout_sec, verify=False)
+            response = requests.get(url, timeout=timeout_sec, verify=False)
         return response
 
     def render_status_by_id(self, *render_ids):

--- a/eyes_core/applitools/core/server_connector.py
+++ b/eyes_core/applitools/core/server_connector.py
@@ -21,7 +21,6 @@ from applitools.common.utils import (
     argument_guard,
     datetime_utils,
     gzip_compress,
-    image_utils,
     json_utils,
     urljoin,
 )
@@ -123,7 +122,8 @@ class _RequestCommunicator(object):
         """
         Closes all adapters and as such the client session.
         """
-        self.client_session.close()
+        if hasattr(self.client_session, "close"):
+            self.client_session.close()
 
     def request(self, method, url_resource, use_api_key=True, **kwargs):
         # type: (Text, Text, bool, **Any) -> Response
@@ -242,12 +242,17 @@ class ServerConnector(object):
         """
         self._render_info = None  # type: Optional[RenderingInfo]
         self._ua_string = None  # type: Optional[RenderingInfo]
-        if client_session:
-            self._com = _RequestCommunicator(
-                headers=ServerConnector.DEFAULT_HEADERS, client_session=client_session,
-            )
-        else:
-            self._com = _RequestCommunicator(headers=ServerConnector.DEFAULT_HEADERS)
+
+        # temporary disable HTTP persistence feature
+        self._com = _RequestCommunicator(
+            headers=ServerConnector.DEFAULT_HEADERS, client_session=requests
+        )
+        # if client_session:
+        #     self._com = _RequestCommunicator(
+        #       headers=ServerConnector.DEFAULT_HEADERS, client_session=client_session,
+        #     )
+        # else:
+        #     self._com = _RequestCommunicator(headers=ServerConnector.DEFAULT_HEADERS)
 
     def update_config(self, conf, render_info=None, ua_string=None):
         if conf.api_key is None:

--- a/eyes_core/applitools/core/server_connector.py
+++ b/eyes_core/applitools/core/server_connector.py
@@ -244,9 +244,6 @@ class ServerConnector(object):
         self._render_info = None  # type: Optional[RenderingInfo]
         self._ua_string = None  # type: Optional[RenderingInfo]
 
-        # FIXME: temporary disable HTTP persistence feature
-        client_session = ClientSession(requests)
-
         if client_session:
             self._com = _RequestCommunicator(
                 headers=ServerConnector.DEFAULT_HEADERS, client_session=client_session,

--- a/eyes_selenium/applitools/selenium/capture/dom_capture.py
+++ b/eyes_selenium/applitools/selenium/capture/dom_capture.py
@@ -9,7 +9,7 @@ import requests
 import tinycss2
 
 from applitools.common import logger
-from applitools.common.utils import datetime_utils, general_utils
+from applitools.common.utils import datetime_utils, is_url_with_scheme, is_absolute_url
 from applitools.common.utils.compat import urljoin
 from applitools.selenium import eyes_selenium_utils
 from applitools.selenium.positioning import ScrollPositionProvider
@@ -232,7 +232,7 @@ def _loop(driver, dom_tree):
 def _get_frame_bundled_css(driver):
     # type: (EyesWebDriver) -> tp.Text
     base_url = driver.current_url  # type: ignore
-    if not general_utils.is_absolute_url(base_url):
+    if not is_absolute_url(base_url):
         logger.info("Base URL is not an absolute URL!")
 
     cssom_results = driver.execute_script(_CAPTURE_CSSOM_SCRIPT)
@@ -320,11 +320,7 @@ def _parse_and_serialize_css(node, text, minimize=False):
 
 def _make_url(base_url, value):
     # type: (tp.Text, tp.Text) -> tp.Text
-    if general_utils.is_absolute_url(
-        value
-    ) and not general_utils.is_url_with_scheme(  # noqa
-        value
-    ):
+    if is_absolute_url(value) and not is_url_with_scheme(value):  # noqa
         url = urljoin("http://", value)
     else:
         url = urljoin(base_url, value)

--- a/eyes_selenium/applitools/selenium/visual_grid/helpers.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/helpers.py
@@ -46,20 +46,23 @@ def collect_test_results(tests, should_raise_exception):
                 )
             )
         exception = None
-        if test.test_result is None:
+        if test_result:
+            scenario_id_or_name = test_result.name
+            app_id_or_name = test_result.app_name
+            if test_result.is_unresolved and not test_result.is_new:
+                exception = DiffsFoundError(
+                    test_result, scenario_id_or_name, app_id_or_name
+                )
+            if test_result.is_new:
+                exception = NewTestError(
+                    test_result, scenario_id_or_name, app_id_or_name
+                )
+            if test_result.is_failed:
+                exception = TestFailedError(
+                    test_result, scenario_id_or_name, app_id_or_name
+                )
+        else:
             exception = TestFailedError("Test haven't finished correctly")
-        scenario_id_or_name = test_result.name
-        app_id_or_name = test_result.app_name
-        if test_result and test_result.is_unresolved and not test_result.is_new:
-            exception = DiffsFoundError(
-                test_result, scenario_id_or_name, app_id_or_name
-            )
-        if test_result and test_result.is_new:
-            exception = NewTestError(test_result, scenario_id_or_name, app_id_or_name)
-        if test_result and test_result.is_failed:
-            exception = TestFailedError(
-                test_result, scenario_id_or_name, app_id_or_name
-            )
         all_results.append(
             TestResultContainer(test_result, test.browser_info, exception)
         )

--- a/eyes_selenium/applitools/selenium/visual_grid/helpers.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/helpers.py
@@ -24,13 +24,10 @@ def wait_till_tests_completed(test_provider):
         return test_provider()
 
     while True:
-        states = [t.state for t in get_tests(test_provider)]
+        states = list(set(t.state for t in get_tests(test_provider)))
         if not states:
             # probably some exception is happened during execution
             break
-        counter = Counter(states)
-        logger.info("Current test states: \n {}".format(counter))
-        states = list(set(states))
         if len(states) == 1 and states[0] == "completed":
             break
         datetime_utils.sleep(

--- a/eyes_selenium/applitools/selenium/visual_grid/helpers.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/helpers.py
@@ -1,0 +1,71 @@
+from typing import TYPE_CHECKING, Union
+from collections import Counter
+
+from applitools.common import (
+    logger,
+    TestFailedError,
+    DiffsFoundError,
+    NewTestError,
+    TestResultContainer,
+    TestResults,
+)
+from applitools.common.utils import datetime_utils, iteritems
+
+if TYPE_CHECKING:
+    from typing import List, Dict, Callable
+    from applitools.selenium.visual_grid import RunningTest
+
+
+def wait_till_tests_completed(test_provider):
+    # type: (Union[Callable, List]) -> None
+    def get_tests(provider):
+        if isinstance(test_provider, list):
+            return test_provider
+        return test_provider()
+
+    while True:
+        states = [t.state for t in get_tests(test_provider)]
+        if not states:
+            # probably some exception is happened during execution
+            break
+        counter = Counter(states)
+        logger.info("Current test states: \n {}".format(counter))
+        states = list(set(states))
+        if len(states) == 1 and states[0] == "completed":
+            break
+        datetime_utils.sleep(
+            1500, msg="Waiting for state completed!",
+        )
+
+
+def collect_test_results(tests, should_raise_exception):
+    # type: (Dict[RunningTest, TestResults], bool) -> List[TestResultContainer]
+    all_results = []
+    for test, test_result in iteritems(tests):
+        if test.pending_exceptions:
+            logger.error(
+                "During test execution above exception raised. \n {:s}".join(
+                    str(e) for e in test.pending_exceptions
+                )
+            )
+        exception = None
+        if test.test_result is None:
+            exception = TestFailedError("Test haven't finished correctly")
+        scenario_id_or_name = test_result.name
+        app_id_or_name = test_result.app_name
+        if test_result and test_result.is_unresolved and not test_result.is_new:
+            exception = DiffsFoundError(
+                test_result, scenario_id_or_name, app_id_or_name
+            )
+        if test_result and test_result.is_new:
+            exception = NewTestError(test_result, scenario_id_or_name, app_id_or_name)
+        if test_result and test_result.is_failed:
+            exception = TestFailedError(
+                test_result, scenario_id_or_name, app_id_or_name
+            )
+        all_results.append(
+            TestResultContainer(test_result, test.browser_info, exception)
+        )
+        if exception and should_raise_exception:
+            raise exception
+    return all_results

--- a/eyes_selenium/applitools/selenium/visual_grid/render_task.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/render_task.py
@@ -301,6 +301,6 @@ def _apply_base_url(discovered_url, base_url, resource_url=None):
     url = urlparse(discovered_url)
     if url.scheme in ["http", "https"] and url.netloc:
         return discovered_url
-    if resource_url and urlparse(resource_url).netloc != urlparse(base_url).netloc:
+    if resource_url:
         base_url = resource_url
     return urljoin(base_url, discovered_url)

--- a/eyes_selenium/applitools/selenium/visual_grid/render_task.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/render_task.py
@@ -61,9 +61,7 @@ class RenderTask(VGTask):
     def __attrs_post_init__(self):
         # type: () -> None
         self.func_to_run = self.perform  # type: Callable
-        self.all_blobs = []  # type: List[VGResource]
         self.request_resources = {}  # type: Dict[Text, VGResource]
-        self.resource_urls = []  # type: List[Text]
 
     def perform(self):  # noqa
         # type: () -> List[RenderStatusResults]
@@ -200,7 +198,7 @@ class RenderTask(VGTask):
         logger.debug("parse_frame_dom_resources() call")
         base_url = data["url"]
         resource_urls = data.get("resourceUrls", [])
-        blobs = data.get("blobs", [])
+        all_blobs = data.get("blobs", [])
         frames = data.get("frames", [])
         discovered_resources_urls = set()
         discovered_resources_lock = Lock()
@@ -234,12 +232,10 @@ class RenderTask(VGTask):
                 f_data
             ).resource
 
-        for blob in blobs:
+        for blob in all_blobs:
             resource = VGResource.from_blob(blob, on_created=handle_resources)
             if resource.url.rstrip("#") == base_url:
                 continue
-
-            self.all_blobs.append(resource)
             self.request_resources[resource.url] = resource
 
         for r_url in set(resource_urls).union(discovered_resources_urls):

--- a/eyes_selenium/applitools/selenium/visual_grid/render_task.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/render_task.py
@@ -15,7 +15,7 @@ from applitools.common import (
     logger,
     RunningRender,
 )
-from applitools.common.utils import datetime_utils, urljoin, urlparse, iteritems
+from applitools.common.utils import datetime_utils, apply_base_url
 from applitools.common.utils.converters import str2bool
 from applitools.common.utils.general_utils import get_env_with_prefix
 from applitools.selenium import parsers
@@ -218,7 +218,7 @@ class RenderTask(VGTask):
                 if discovered_url.startswith("data:"):
                     # resource already in blob
                     continue
-                target_url = _apply_base_url(discovered_url, base_url, resource_url)
+                target_url = apply_base_url(discovered_url, base_url, resource_url)
                 with self.discovered_resources_lock:
                     discovered_resources_urls.append(target_url)
 
@@ -229,7 +229,7 @@ class RenderTask(VGTask):
             return VGResource.from_response(link, response, on_created=handle_resources)
 
         for f_data in frames:
-            f_data["url"] = _apply_base_url(f_data["url"], base_url)
+            f_data["url"] = apply_base_url(f_data["url"], base_url)
             self.request_resources[f_data["url"]] = self.parse_frame_dom_resources(
                 f_data
             ).resource
@@ -306,12 +306,3 @@ class RenderTask(VGTask):
             )
         self.running_tests.append(running_test)
         return len(self.running_tests) - 1
-
-
-def _apply_base_url(discovered_url, base_url, resource_url=None):
-    url = urlparse(discovered_url)
-    if url.scheme in ["http", "https"] and url.netloc:
-        return discovered_url
-    if resource_url:
-        base_url = resource_url
-    return urljoin(base_url, discovered_url)

--- a/eyes_selenium/applitools/selenium/visual_grid/render_task.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/render_task.py
@@ -94,6 +94,8 @@ class RenderTask(VGTask):
                 datetime_utils.sleep(
                     1500, msg="/render throws exception... sleeping for 1.5s"
                 )
+            if fetch_fails > self.MAX_FAILS_COUNT:
+                raise EyesError("Render is failed. Max count retries reached")
             if not render_requests:
                 logger.error("running_renders is null")
                 continue
@@ -268,6 +270,10 @@ class RenderTask(VGTask):
                 finally:
                     iterations += 1
                     datetime_utils.sleep(1500, msg="Rendering...")
+                if iterations > self.MAX_ITERATIONS:
+                    raise EyesError(
+                        "Max iterations in poll_render_status has been reached"
+                    )
                 if statuses or 0 < fails_count < 3:
                     break
             finished = bool(

--- a/eyes_selenium/applitools/selenium/visual_grid/render_task.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/render_task.py
@@ -215,8 +215,8 @@ class RenderTask(VGTask):
             if content_type.startswith("image/svg"):
                 urls_from_svg = parsers.get_urls_from_svg_resource(content)
             for discovered_url in urls_from_css + urls_from_svg:
-                if discovered_url.startswith("data:"):
-                    # resource already in blob
+                if discovered_url.startswith("data:") or discovered_url.startswith("#"):
+                    # resource already in blob or not relevant
                     continue
                 target_url = apply_base_url(discovered_url, base_url, resource_url)
                 with self.discovered_resources_lock:

--- a/eyes_selenium/applitools/selenium/visual_grid/render_task.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/render_task.py
@@ -250,14 +250,12 @@ class RenderTask(VGTask):
         for r_url in discovered_resources_urls:
             self.resource_cache.fetch_and_store(r_url, get_resource)
 
-        # TODO: check missing resources
         for r_url in set(resource_urls).union(discovered_resources_urls):
             val = self.resource_cache[r_url]
             if val is None:
                 logger.debug("No response for {}".format(r_url))
                 continue
             self.request_resources[r_url] = self.resource_cache[r_url]
-
         return RGridDom(
             url=base_url, dom_nodes=data["cdt"], resources=self.request_resources
         )

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
@@ -238,7 +238,7 @@ class VisualGridEyes(object):
                 # probably some exception is happened during execution
                 break
             counter = Counter(states)
-            logger.debug("Current test states: \n {}".format(counter))
+            logger.info("Current test states: \n {}".format(counter))
             states = list(set(states))
             if len(states) == 1 and states[0] == "completed":
                 break

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
@@ -2,7 +2,7 @@ import json
 import threading
 import typing
 import uuid
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 
 import attr
 
@@ -233,8 +233,10 @@ class VisualGridEyes(object):
         self.close_async()
 
         while True:
-            states = list(set(t.state for t in self.test_list))
-            logger.debug("Current test states: \n {}".format(states))
+            states = [t.state for t in self.test_list]
+            counter = Counter(states)
+            logger.debug("Current test states: \n {}".format(counter))
+            states = list(set(states))
             if len(states) == 1 and states[0] == "completed":
                 break
             datetime_utils.sleep(

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
@@ -234,6 +234,9 @@ class VisualGridEyes(object):
 
         while True:
             states = [t.state for t in self.test_list]
+            if not states:
+                # probably some exception is happened during execution
+                break
             counter = Counter(states)
             logger.debug("Current test states: \n {}".format(counter))
             states = list(set(states))

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
@@ -239,9 +239,7 @@ class VisualGridEyes(object):
         )
         if not all_results:
             return TestResults()
-        result = all_results[0].test_results
-        logger.info(str(result))
-        return result
+        return all_results[0].test_results
 
     def abort_async(self):
         """

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_eyes.py
@@ -2,26 +2,24 @@ import json
 import threading
 import typing
 import uuid
-from collections import OrderedDict, Counter
+from collections import OrderedDict
 
 import attr
 
 from applitools.common import (
-    DiffsFoundError,
     EyesError,
-    NewTestError,
-    TestFailedError,
     TestResults,
     logger,
     RectangleSize,
 )
-from applitools.common.utils import argument_guard, datetime_utils
+from applitools.common.utils import argument_guard
 from applitools.common.visual_grid import RenderBrowserInfo, VisualGridSelector
 from applitools.core import CheckSettings, GetRegion
 from applitools.selenium import __version__, eyes_selenium_utils, resource
 from applitools.selenium.fluent import SeleniumCheckSettings
 
 from .eyes_connector import EyesConnector
+from .helpers import collect_test_results, wait_till_tests_completed
 from .running_test import RunningTest
 from .visual_grid_runner import VisualGridRunner
 
@@ -232,47 +230,18 @@ class VisualGridEyes(object):
         logger.debug("VisualGridEyes.close()\n\t test_list %s" % self.test_list)
         self.close_async()
 
-        while True:
-            states = [t.state for t in self.test_list]
-            if not states:
-                # probably some exception is happened during execution
-                break
-            counter = Counter(states)
-            logger.info("Current test states: \n {}".format(counter))
-            states = list(set(states))
-            if len(states) == 1 and states[0] == "completed":
-                break
-            datetime_utils.sleep(
-                1500, msg="Waiting for state completed in VisualGridEyes.close"
-            )
+        wait_till_tests_completed(self.test_list)
 
         self._is_opened = False
 
-        for test in self.test_list:
-            if test.pending_exceptions:
-                logger.error(
-                    "During test execution above exception raised. \n {:s}".join(
-                        str(e) for e in test.pending_exceptions
-                    )
-                )
-        if raise_ex:
-            for test in self.test_list:
-                if test.test_result is None:
-                    raise TestFailedError("Test haven't finished correctly")
-                results = test.test_result
-                scenario_id_or_name = results.name
-                app_id_or_name = results.app_name
-                if results.is_unresolved and not results.is_new:
-                    raise DiffsFoundError(results, scenario_id_or_name, app_id_or_name)
-                if results.is_new:
-                    raise NewTestError(results, scenario_id_or_name, app_id_or_name)
-                if results.is_failed:
-                    raise TestFailedError(results, scenario_id_or_name, app_id_or_name)
-
-        all_results = [t.test_result for t in self.test_list if t.test_result]
+        all_results = collect_test_results(
+            {t: t.test_result for t in self.test_list}, raise_ex
+        )
         if not all_results:
             return TestResults()
-        return all_results[0]
+        result = all_results[0].test_results
+        logger.info(str(result))
+        return result
 
     def abort_async(self):
         """

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
@@ -106,6 +106,9 @@ class VisualGridRunner(EyesRunner):
         # type: (bool) -> TestResultsSummary
         while True:
             states = [t.state for t in self._get_all_running_tests()]
+            if not states:
+                # probably some exception is happened during execution
+                break
             counter = Counter(states)
             logger.debug("Current test states: \n {}".format(counter))
             states = list(set(states))

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
@@ -112,7 +112,7 @@ class VisualGridRunner(EyesRunner):
                 1500, msg="Waiting for state completed in get_all_test_results_impl",
             )
         # finish processing of all tasks and shutdown threads
-        self.stop()
+        self._stop()
 
         all_results = []
         for test, test_result in iteritems(self._all_test_results):

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
@@ -110,13 +110,14 @@ class VisualGridRunner(EyesRunner):
                 # probably some exception is happened during execution
                 break
             counter = Counter(states)
-            logger.debug("Current test states: \n {}".format(counter))
+            logger.info("Current test states: \n {}".format(counter))
             states = list(set(states))
             if len(states) == 1 and states[0] == "completed":
                 break
             datetime_utils.sleep(
                 1500, msg="Waiting for state completed in get_all_test_results_impl",
             )
+        logger.info("Closing all related threads...")
         # finish processing of all tasks and shutdown threads
         self._stop()
 

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
@@ -111,6 +111,8 @@ class VisualGridRunner(EyesRunner):
             datetime_utils.sleep(
                 1500, msg="Waiting for state completed in get_all_test_results_impl",
             )
+        # finish processing of all tasks and shutdown threads
+        self.stop()
 
         all_results = []
         for test, test_result in iteritems(self._all_test_results):

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
@@ -4,6 +4,7 @@ import operator
 import sys
 import threading
 import typing
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 
 from applitools.common import (
@@ -104,8 +105,10 @@ class VisualGridRunner(EyesRunner):
     def _get_all_test_results_impl(self, should_raise_exception=True):
         # type: (bool) -> TestResultsSummary
         while True:
-            states = list(set(t.state for t in self._get_all_running_tests()))
-            logger.debug("Current test states: \n {}".format(states))
+            states = [t.state for t in self._get_all_running_tests()]
+            counter = Counter(states)
+            logger.debug("Current test states: \n {}".format(counter))
+            states = list(set(states))
             if len(states) == 1 and states[0] == "completed":
                 break
             datetime_utils.sleep(

--- a/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
+++ b/eyes_selenium/applitools/selenium/visual_grid/visual_grid_runner.py
@@ -35,7 +35,7 @@ class VisualGridRunner(EyesRunner):
     def __init__(self, concurrent_sessions=None):
         # type: (Optional[int]) -> None
         super(VisualGridRunner, self).__init__()
-        self._all_test_result = {}  # type: Dict[RunningTest, TestResults]
+        self._all_test_results = {}  # type: Dict[RunningTest, TestResults]
 
         kwargs = {}
         if sys.version_info >= (3, 6):
@@ -62,7 +62,7 @@ class VisualGridRunner(EyesRunner):
         logger.debug(
             "aggregate_result({}, {}) called".format(test.test_uuid, test_result)
         )
-        self._all_test_result[test] = test_result
+        self._all_test_results[test] = test_result
 
     def open(self, eyes):
         # type: (VisualGridEyes) -> None
@@ -113,7 +113,7 @@ class VisualGridRunner(EyesRunner):
             )
 
         all_results = []
-        for test, test_result in iteritems(self._all_test_result):
+        for test, test_result in iteritems(self._all_test_results):
             if test.pending_exceptions:
                 logger.error(
                     "During test execution above exception raised. \n {:s}".join(

--- a/tests/unit/eyes_common/test_url_utils.py
+++ b/tests/unit/eyes_common/test_url_utils.py
@@ -1,0 +1,15 @@
+import pytest
+
+from applitools.common.utils import apply_base_url
+
+
+@pytest.mark.parametrize(
+    "discovered_url,site_base_url,resource_url,result",
+    [
+        ["#some", "https://some.com/some", None, "https://some.com/some#some"],
+        ["/some/url", "https://some.com", "/no-host-url", "https://some.com/some/url"],
+        ["url", "https://som.com", "https://som.com/yes/", "https://som.com/yes/url"],
+    ],
+)
+def test_apply_base_url(discovered_url, site_base_url, resource_url, result):
+    assert apply_base_url(discovered_url, site_base_url, resource_url) == result


### PR DESCRIPTION
* fix: close all threads when get_all_test_results called
* fix: infinite loop if rendering is failed
* fix: break test execution if test list empty
* fix: wrong url merging in _apply_base_url
* fix(visualgrid): skip URLs which start from `#` in `handle_resources`
* fix(visualgrid): test_results is None cause exception in `collect_test_results()`

* chore: improve logging verbosity
* chore: use `requests` instead of `Session` for download_resource
* chore: print current tests state if logging level INFO

* refactor: move url function to url_utils.py
* refactor: rename param base_url to site_base_url of apply_base_url
* refactor: extract common code between VGE.close and VGR._get_all_results to helpers.py
* refactor: remove unused variables


* docs: update CHANGELOG.md