### PR TITLE
Bug Fix for mypy typing

### DIFF
--- a/eyes_core/applitools/core/batch_close.py
+++ b/eyes_core/applitools/core/batch_close.py
@@ -62,7 +62,7 @@ class BatchClose(object):
         return self
 
     def set_batch_ids(self, *ids):
-        # type: (Union[*Text, List[Text]]) -> _EnabledBatchClose
+        # type: (Union[Text, List[Text]]) -> _EnabledBatchClose
         if isinstance(ids[0], list):
             ids = ids[0]
         return _EnabledBatchClose(ids, self.server_url, self.api_key)


### PR DESCRIPTION
The character * in the [batch_close.py file](https://github.com/applitools/eyes.sdk.python/blob/c00b182bdede3166bdc3cdbf96f171a2e920dbb5/eyes_core/applitools/core/batch_close.py#L65) in line 65 was producing a syntax error when you execute [mypy library](http://mypy-lang.org).

Steps to reproduce:
```
python3 -m venv env
env/bin/pip install mypy eyes-selenium
env/bin/python -m mypy env/lib/python3.6/site-packages/
```
Output:

> env/lib/python3.6/site-packages/applitools/core/batch_close.py:64: error: syntax error in type comment '(Union[*Text, List[Text]]) -> _EnabledBatchClose'
Found 1 error in 1 file (checked 838 source files)

After deleting the character the error disappear.