### PR TITLE
Fix 'list index out of range'

### DIFF
--- a/eyes_core/applitools/core/match_window_task.py
+++ b/eyes_core/applitools/core/match_window_task.py
@@ -55,16 +55,8 @@ def collect_regions_from_selectors(image_match_settings, regions, region_selecto
         [],  # Target Element Location
     ]
     for region in regions:
-        can_add_region = False
-        while not can_add_region:
-            current_counter += 1
-            if current_counter > current_type_region_count:
-                current_type_index += 1
-                current_type_region_count = len(region_selectors[current_type_index])
-                current_counter = 0
-            else:
-                can_add_region = True
         mutable_regions[current_type_index].append(region)
+        current_type_index+=1
 
     # location = Point.ZERO()
 


### PR DESCRIPTION
**Issue**
Combining the element check with regular window check does not seem to work.
When `region_selectors` has empty regions an `IndexError` will be raised  since the while loop base case will not be reached.