### PR TITLE
Bugfix Trello 1684 Test works fine with Python 3.7 but does not work with Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
           addons:
               chrome: stable
           env:
-              - TOX_ENV=desktop
+              - TOX_ENV=selenium
               - TEST_PLATFORM=Linux
               - TEST_BROWSERS=chrome
         - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,13 @@ jobs:
               - TOX_ENV=desktop
               - TEST_PLATFORM=Linux
               - TEST_BROWSERS=chrome
+        - python: 2.7
+          addons:
+              chrome: stable
+          env:
+              - TOX_ENV=desktop
+              - TEST_PLATFORM=Linux
+              - TEST_BROWSERS=chrome
         - python: 3.6
           addons:
               chrome: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Fixed
+- Tests doesn't work with Python 2 when coded region is used [Trello 1684](https://trello.com/c/K1Bv5OK7) [GH #146](https://github.com/applitools/eyes.sdk.python/pull/146)
+
 # [4.1.23] - 2020-03-25
 ## Fixed
 - VG tests hang intermittently [Trello 1566](https://trello.com/c/kU2EaDiE)

--- a/eyes_common/applitools/common/geometry.py
+++ b/eyes_common/applitools/common/geometry.py
@@ -58,17 +58,13 @@ class CoordinatesType(Enum):
 class RectangleSize(DictAccessMixin):
     """Represents a 2D size"""
 
-    width = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type: int
-    height = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type:int
+    width = attr.ib(metadata={JsonInclude.THIS: True})  # type: int
+    height = attr.ib(metadata={JsonInclude.THIS: True})  # type:int
 
     def __init__(self, width, height):
         # type: (int, int) -> None
-        self.width = width
-        self.height = height
+        self.width = round_converter(width)
+        self.height = round_converter(height)
 
     def __str__(self):
         return "RectangleSize({width} x {height})".format(
@@ -106,17 +102,13 @@ class RectangleSize(DictAccessMixin):
 class Point(DictAccessMixin):
     """A location in a two-dimensional plane."""
 
-    x = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type: int
-    y = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type: int
+    x = attr.ib(metadata={JsonInclude.THIS: True})  # type: int
+    y = attr.ib(metadata={JsonInclude.THIS: True})  # type: int
 
     def __init__(self, x, y):
         # type: (int, int) -> None
-        self.x = x
-        self.y = y
+        self.x = round_converter(x)
+        self.y = round_converter(y)
 
     def __str__(self):
         return "Point({x} x {y})".format(x=self.x, y=self.y)
@@ -212,18 +204,10 @@ class Point(DictAccessMixin):
 class Region(DictAccessMixin):
     """A rectangle identified by left,top, width, height."""
 
-    left = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type: int
-    top = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type: int
-    width = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type: int
-    height = attr.ib(
-        converter=round_converter, metadata={JsonInclude.THIS: True}
-    )  # type: int
+    left = attr.ib(metadata={JsonInclude.THIS: True})  # type: int
+    top = attr.ib(metadata={JsonInclude.THIS: True})  # type: int
+    width = attr.ib(metadata={JsonInclude.THIS: True})  # type: int
+    height = attr.ib(metadata={JsonInclude.THIS: True})  # type: int
     coordinates_type = attr.ib(
         metadata={JsonInclude.THIS: True}
     )  # type: CoordinatesType
@@ -237,10 +221,10 @@ class Region(DictAccessMixin):
         coordinates_type=CoordinatesType.SCREENSHOT_AS_IS,  # type: CoordinatesType
     ):
         # type: (...) -> None
-        self.left = left
-        self.top = top
-        self.width = width
-        self.height = height
+        self.left = round_converter(left)
+        self.top = round_converter(top)
+        self.width = round_converter(width)
+        self.height = round_converter(height)
         self.coordinates_type = coordinates_type
 
     def __str__(self):

--- a/eyes_common/applitools/common/logger.py
+++ b/eyes_common/applitools/common/logger.py
@@ -258,7 +258,7 @@ def warning(msg):
 
     :param msg: The message that will be written to the log.
     """
-    warnings.warn(msg)
+    warnings.warn(msg, stacklevel=2)
 
 
 def deprecation(msg):

--- a/eyes_core/applitools/core/server_connector.py
+++ b/eyes_core/applitools/core/server_connector.py
@@ -4,7 +4,6 @@ import json
 import math
 import typing
 import uuid
-from struct import pack
 
 import attr
 import requests
@@ -204,15 +203,6 @@ class _RequestCommunicator(object):
         if response.status_code != requests.codes.ok:
             return response
         return self._long_request_loop(url, delay)
-
-
-def prepare_match_data(match_data):
-    # type: (MatchWindowData) -> bytes
-    match_data_json = json_utils.to_json(match_data)
-    logger.debug("MatchWindowData {}".format(match_data_json))
-    match_data_json_bytes = match_data_json.encode("utf-8")  # type: bytes
-    match_data_size_bytes = pack(">L", len(match_data_json_bytes))  # type: bytes
-    return match_data_size_bytes + match_data_json_bytes
 
 
 class ServerConnector(object):
@@ -422,10 +412,8 @@ class ServerConnector(object):
             raise EyesError(
                 "MatchWindow failed: could not upload image to storage service."
             )
-        data = prepare_match_data(match_data)
-        # Using the default headers, but modifying the "content type" to binary
+        data = json_utils.to_json(match_data)
         headers = ServerConnector.DEFAULT_HEADERS.copy()
-        headers["Content-Type"] = "application/octet-stream"
         response = self._com.long_request(
             "post",
             url_resource=urljoin(self.API_SESSIONS_RUNNING, running_session.id),

--- a/eyes_selenium/applitools/selenium/capture/dom_capture.py
+++ b/eyes_selenium/applitools/selenium/capture/dom_capture.py
@@ -294,7 +294,7 @@ def _parse_and_serialize_css(node, text, minimize=False):
             continue
 
         try:
-            if minimize:
+            if minimize and style_node.content:
                 try:
                     # remove whitespaces inside blocks
                     style_node.content = [

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -153,6 +153,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
         return self._frame_chain
 
     def location_in_screenshot(self, location, coordinates_type):
+        # type: (Point, CoordinatesType) -> Point
         location = self.convert_location(
             location, coordinates_type, self.SCREENSHOT_AS_IS
         )
@@ -165,24 +166,26 @@ class EyesWebDriverScreenshot(EyesScreenshot):
         return location
 
     def sub_screenshot(self, region, throw_if_clipped=False):
+        # type: (Region, bool) -> EyesWebDriverScreenshot
         # We calculate intersection based on as-is coordinates.
         as_is_sub_screenshot_region = self.intersected_region(
             region, self.SCREENSHOT_AS_IS
         )
-        if as_is_sub_screenshot_region.is_size_empty or (
-            throw_if_clipped and not as_is_sub_screenshot_region.size == region.size
+        if (
+            as_is_sub_screenshot_region.is_size_empty
+            or throw_if_clipped
+            and as_is_sub_screenshot_region.size != region.size
         ):
             raise OutOfBoundsError(
                 "Region [%s] is out of screenshot bounds [%s]"
                 % (region, self.frame_window)
             )
         sub_image = image_utils.get_image_part(self.image, as_is_sub_screenshot_region)
-        result = EyesWebDriverScreenshot.from_screenshot(
+        return EyesWebDriverScreenshot.from_screenshot(
             self._driver,
             sub_image,
             Region(region.left, region.top, sub_image.width, sub_image.height),
         )
-        return result
 
     CONTEXT_RELATIVE = CoordinatesType.CONTEXT_RELATIVE
     SCREENSHOT_AS_IS = CoordinatesType.SCREENSHOT_AS_IS
@@ -207,17 +210,19 @@ class EyesWebDriverScreenshot(EyesScreenshot):
             and self._screenshot_type == ScreenshotType.ENTIRE_FRAME
         ):
             if (
-                from_ == self.CONTEXT_RELATIVE or from_ == self.CONTEXT_AS_IS
-            ) and to == self.SCREENSHOT_AS_IS:
+                from_ in [self.CONTEXT_RELATIVE, self.CONTEXT_AS_IS]
+                and to == self.SCREENSHOT_AS_IS
+            ):
                 # If this is not a sub-screenshot, this will have no effect.
                 result = result.offset(self._frame_location_in_screenshot)
                 # If this is not a region subscreenshot, this will have no effect.
                 result = result.offset(
                     -self.region_window.left, -self.region_window.top
                 )
-            elif from_ == self.SCREENSHOT_AS_IS and (
-                to == self.CONTEXT_RELATIVE or to == self.CONTEXT_AS_IS
-            ):
+            elif from_ == self.SCREENSHOT_AS_IS and to in [
+                self.CONTEXT_RELATIVE,
+                self.CONTEXT_AS_IS,
+            ]:
                 result = result.offset(-self._frame_location_in_screenshot)
             return result
 
@@ -266,12 +271,8 @@ class EyesWebDriverScreenshot(EyesScreenshot):
             region, original_coordinates_type, self.SCREENSHOT_AS_IS
         )
         #  If the request was context based, we intersect with the frame window.
-        if (
-            original_coordinates_type == self.CONTEXT_AS_IS
-            or original_coordinates_type == self.CONTEXT_RELATIVE
-        ):
+        if original_coordinates_type in [self.CONTEXT_AS_IS, self.CONTEXT_RELATIVE]:
             intersected_region = intersected_region.intersect(self.frame_window)
-        # If the request is screenshot based, we intersect with the image
         elif original_coordinates_type == self.SCREENSHOT_AS_IS:
             intersected_region = intersected_region.intersect(
                 Region(0, 0, self.image.width, self.image.height)

--- a/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
+++ b/eyes_selenium/applitools/selenium/capture/eyes_webdriver_screenshot.py
@@ -273,6 +273,7 @@ class EyesWebDriverScreenshot(EyesScreenshot):
         #  If the request was context based, we intersect with the frame window.
         if original_coordinates_type in [self.CONTEXT_AS_IS, self.CONTEXT_RELATIVE]:
             intersected_region = intersected_region.intersect(self.frame_window)
+        # If the request is screenshot based, we intersect with the image
         elif original_coordinates_type == self.SCREENSHOT_AS_IS:
             intersected_region = intersected_region.intersect(
                 Region(0, 0, self.image.width, self.image.height)

--- a/tests/functional/eyes_selenium/conftest.py
+++ b/tests/functional/eyes_selenium/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import re
 import sys
@@ -7,7 +9,6 @@ from distutils.util import strtobool
 from itertools import chain
 
 import pytest
-from mock import MagicMock
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from webdriver_manager.chrome import ChromeDriverManager
@@ -15,10 +16,8 @@ from webdriver_manager.firefox import GeckoDriverManager
 from webdriver_manager.microsoft import EdgeDriverManager, IEDriverManager
 
 from applitools.selenium import (
-    BatchInfo,
     Eyes,
     StitchMode,
-    eyes_selenium_utils,
     Configuration,
     logger,
 )

--- a/tests/unit/eyes_common/test_geometry.py
+++ b/tests/unit/eyes_common/test_geometry.py
@@ -1,0 +1,45 @@
+import pytest
+
+from applitools.common import Region, CoordinatesType, Point, RectangleSize
+
+
+@pytest.mark.parametrize(
+    "left,top,width,height,coord_type,result",
+    [
+        [
+            0,
+            0,
+            0,
+            0,
+            CoordinatesType.CONTEXT_AS_IS,
+            Region(0, 0, 0, 0, CoordinatesType.CONTEXT_AS_IS),
+        ],
+        [
+            1,
+            2.0,
+            3.0,
+            4.0,
+            CoordinatesType.SCREENSHOT_AS_IS,
+            Region(1, 2, 3, 4, CoordinatesType.SCREENSHOT_AS_IS),
+        ],
+    ],
+)
+def test_region_creation(left, top, width, height, coord_type, result):
+    expect = Region(left, top, width, height, coord_type)
+    assert expect == result
+
+
+@pytest.mark.parametrize(
+    "x,y,result", [[0, 0, Point(0, 0)], [1, 2.0, Point(1, 2)]],
+)
+def test_point_creation(x, y, result):
+    expect = Point(x, y)
+    assert expect == result
+
+
+@pytest.mark.parametrize(
+    "width,height,result", [[0, 0, RectangleSize(0, 0)], [1, 2.0, RectangleSize(1, 2)]],
+)
+def test_rectangle_size_creation(width, height, result):
+    expect = RectangleSize(width, height)
+    assert expect == result


### PR DESCRIPTION
[Trello 1684](https://trello.com/c/K1Bv5OK7) 

The issue was reproduced only when some coded region is used (e.g. `.ignore()`). The someway with Python 2 the selenium returns position in float number while with Python 3 it was integer. Because the type conversion in Region and Point were broken we've send float number to the server which lead to 400 Bad Request.

I've added type conversion and unit test for them. I also brought back Python 2 selenium test execution on travis ci.