### PR TITLE
Add test HelloWorld, update Abort tests, move skip to .yaml file

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -167,17 +167,17 @@ if RUNNING_ON_TRAVIS_REGRESSION_SUITE:
         if strtobool(os.getenv("TEST_RUN_ON_VG", "False")):
             if "VG" in failed_tests[item.fspath.basename][item.originalname][0]:
                 item.add_marker(skip)
+        else:
+            if ("stitch_mode" in item.callspec.params) and (
+                item.callspec.params["stitch_mode"].value
+                in failed_tests[item.fspath.basename][item.originalname][0]
+            ):
+                item.add_marker(skip)
             if ("eyes_runner" in item.callspec.params) and (
                 string_contains_list_element(
                     str(type(item.callspec.params["eyes_runner"])),
                     failed_tests[item.fspath.basename][item.originalname][0],
                 )
-            ):
-                item.add_marker(skip)
-        else:
-            if ("stitch_mode" in item.callspec.params) and (
-                item.callspec.params["stitch_mode"].value
-                in failed_tests[item.fspath.basename][item.originalname][0]
             ):
                 item.add_marker(skip)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -167,9 +167,11 @@ if RUNNING_ON_TRAVIS_REGRESSION_SUITE:
         if strtobool(os.getenv("TEST_RUN_ON_VG", "False")):
             if "VG" in failed_tests[item.fspath.basename][item.originalname][0]:
                 item.add_marker(skip)
-            if string_contains_list_element(
-                str(type(item.callspec.params["eyes_runner"])),
-                failed_tests[item.fspath.basename][item.originalname][0],
+            if ("eyes_runner" in item.callspec.params) and (
+                string_contains_list_element(
+                    str(type(item.callspec.params["eyes_runner"])),
+                    failed_tests[item.fspath.basename][item.originalname][0],
+                )
             ):
                 item.add_marker(skip)
         else:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -175,7 +175,7 @@ if RUNNING_ON_TRAVIS_REGRESSION_SUITE:
             ):
                 item.add_marker(skip)
         else:
-            if (
+            if ("stitch_mode" in item.callspec.params) and (
                 item.callspec.params["stitch_mode"].value
                 in failed_tests[item.fspath.basename][item.originalname][0]
             ):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -167,6 +167,11 @@ if RUNNING_ON_TRAVIS_REGRESSION_SUITE:
         if strtobool(os.getenv("TEST_RUN_ON_VG", "False")):
             if "VG" in failed_tests[item.fspath.basename][item.originalname][0]:
                 item.add_marker(skip)
+            if string_contains_list_element(
+                str(type(item.callspec.params["eyes_runner"])),
+                failed_tests[item.fspath.basename][item.originalname][0],
+            ):
+                item.add_marker(skip)
         else:
             if (
                 item.callspec.params["stitch_mode"].value
@@ -186,3 +191,9 @@ if RUNNING_ON_TRAVIS_REGRESSION_SUITE:
                 and item.callspec.params["page"] in excluded_item
             ):
                 item.add_marker(skip)
+
+    def string_contains_list_element(string_check, list_check):
+        for element in list_check:
+            if element in string_check:
+                return True
+        return False

--- a/tests/functional/eyes_selenium/desktop/test_classic_api.py
+++ b/tests/functional/eyes_selenium/desktop/test_classic_api.py
@@ -35,19 +35,16 @@ def test_check_region2(eyes_opened):
     )
 
 
-@pytest.mark.selenium_only
 def test_check_frame(eyes_opened):
     eyes_opened.check_frame("frame1", tag="frame1")
 
 
-@pytest.mark.selenium_only
 def test_check_region_in_frame(eyes_opened):
     eyes_opened.check_region_in_frame(
         "frame1", [By.ID, "inner-frame-div"], tag="Inner frame div", stitch_content=True
     )
 
 
-@pytest.mark.selenium_only
 def test_check_inner_frame(eyes_opened):
     eyes_opened.hide_scrollbars = False
     eyes_opened.driver.execute_script("document.documentElement.scrollTo(0,350);")

--- a/tests/functional/eyes_selenium/desktop/test_special_cases.py
+++ b/tests/functional/eyes_selenium/desktop/test_special_cases.py
@@ -4,7 +4,6 @@ from selenium.webdriver.common.by import By
 from applitools.selenium import Target
 
 pytestmark = [
-    pytest.mark.selenium_only,
     pytest.mark.platform("Linux"),
     pytest.mark.viewport_size({"width": 700, "height": 460}),
     pytest.mark.test_suite_name("Eyes Selenium SDK - Special Cases"),

--- a/tests/functional/eyes_selenium/selenium/test_specific_cases.py
+++ b/tests/functional/eyes_selenium/selenium/test_specific_cases.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from selenium.webdriver.common.by import By
 
 from applitools.selenium import (
@@ -10,6 +11,7 @@ from applitools.selenium import (
 )
 
 
+@pytest.mark.skip("Old test. test_hello_world implemented instead of this one")
 @pytest.mark.platform("Linux")
 @pytest.mark.test_page_url("https://applitools.com/helloworld")
 def test_quickstart_example(eyes, driver):
@@ -63,10 +65,11 @@ def test_check_window_with_send_dom(eyes, driver):
     eyes.close()
 
 
-@pytest.mark.test_page_url("https://demo.applitools.com/")
+@pytest.mark.test_page_url("data:text/html,<p>Test</p>")
 def test_abort_eyes(eyes, driver):
-    eyes.open(driver, "Python | VisualGrid", "TestAbortSeleniumEyes")
-    eyes.check_window()
+    eyes.open(driver, "Test Abort", "Test Abort", {"width": 1200, "height": 800})
+    eyes.check("SEL", Target.window())
+    time.sleep(15)
     eyes.abort()
 
 

--- a/tests/functional/eyes_selenium/visual_grid/test_aborts.py
+++ b/tests/functional/eyes_selenium/visual_grid/test_aborts.py
@@ -1,3 +1,4 @@
+import time
 from mock import patch
 
 from applitools.common import RenderStatus, RenderStatusResults
@@ -27,12 +28,13 @@ def test_abort_when_not_rendered(driver, vg_runner, batch_info):
 
 def test_abort_async_on_vg(driver, vg_runner, batch_info):
     eyes = Eyes(vg_runner)
-    eyes.configure.test_name = "TestAbortAsync"
-    eyes.configure.app_name = "Visual Grid Render Test"
+    eyes.configure.test_name = "Test Abort_VG"
+    eyes.configure.app_name = "Test Abort_VG"
     eyes.configure.batch = batch_info
-    eyes.configure.add_browser(1200, 800, BrowserType.CHROME)
-    driver.get("https://demo.applitools.com")
+    eyes.configure.add_browser(800, 600, BrowserType.CHROME)
+    driver.get("data:text/html,<p>Test</p>")
     eyes.open(driver)
-    eyes.check("", Target.window())
+    eyes.check("VG", Target.window())
+    time.sleep(15)
     eyes.abort_async()
     all_results = vg_runner.get_all_test_results(False)

--- a/tests/functional/eyes_selenium/visual_grid/test_double_open_close.py
+++ b/tests/functional/eyes_selenium/visual_grid/test_double_open_close.py
@@ -8,20 +8,20 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture()
-def test_name_suffix(eyes_runner):
+def name_suffix(eyes_runner):
     if isinstance(eyes_runner, ClassicRunner):
         return ""
     else:
         return "_VG"
 
 
-def test_double_open_check_close(driver, eyes_runner, test_name_suffix):
+def test_double_open_check_close(driver, eyes_runner, name_suffix):
     eyes = Eyes(eyes_runner)
     driver.get("https://applitools.github.io/demo/TestPages/VisualGridTestPage/")
     eyes.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckClose" + test_name_suffix,
+        "TestDoubleOpenCheckClose" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes.check("Step 1", Target.window().fully().ignore_displacements(False))
@@ -30,7 +30,7 @@ def test_double_open_check_close(driver, eyes_runner, test_name_suffix):
     eyes.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckClose" + test_name_suffix,
+        "TestDoubleOpenCheckClose" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes.check("Step 2", Target.window().fully().ignore_displacements(False))
@@ -40,13 +40,13 @@ def test_double_open_check_close(driver, eyes_runner, test_name_suffix):
     assert len(all_test_results.all_results) == 2
 
 
-def test_double_open_check_close_async(driver, eyes_runner, test_name_suffix):
+def test_double_open_check_close_async(driver, eyes_runner, name_suffix):
     eyes = Eyes(eyes_runner)
     driver.get("https://applitools.github.io/demo/TestPages/VisualGridTestPage/")
     eyes.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckCloseAsync" + test_name_suffix,
+        "TestDoubleOpenCheckCloseAsync" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes.check("Step 1", Target.window().fully().ignore_displacements(False))
@@ -55,7 +55,7 @@ def test_double_open_check_close_async(driver, eyes_runner, test_name_suffix):
     eyes.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckCloseAsync" + test_name_suffix,
+        "TestDoubleOpenCheckCloseAsync" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes.check("Step 2", Target.window().fully().ignore_displacements(False))
@@ -66,14 +66,14 @@ def test_double_open_check_close_async(driver, eyes_runner, test_name_suffix):
 
 
 def test_double_open_check_close_with_different_instances(
-    driver, eyes_runner, test_name_suffix
+    driver, eyes_runner, name_suffix
 ):
     eyes1 = Eyes(eyes_runner)
     driver.get("https://applitools.github.io/demo/TestPages/VisualGridTestPage/")
     eyes1.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckCloseWithDifferentInstances" + test_name_suffix,
+        "TestDoubleOpenCheckCloseWithDifferentInstances" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes1.check("Step 1", Target.window().fully().ignore_displacements(False))
@@ -83,7 +83,7 @@ def test_double_open_check_close_with_different_instances(
     eyes2.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckCloseWithDifferentInstances" + test_name_suffix,
+        "TestDoubleOpenCheckCloseWithDifferentInstances" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes2.check("Step 2", Target.window().fully().ignore_displacements(False))
@@ -94,14 +94,14 @@ def test_double_open_check_close_with_different_instances(
 
 
 def test_double_open_check_close_async_with_different_instances(
-    driver, eyes_runner, test_name_suffix
+    driver, eyes_runner, name_suffix
 ):
     eyes1 = Eyes(eyes_runner)
     driver.get("https://applitools.github.io/demo/TestPages/VisualGridTestPage/")
     eyes1.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckCloseAsyncWithDifferentInstances" + test_name_suffix,
+        "TestDoubleOpenCheckCloseAsyncWithDifferentInstances" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes1.check("Step 1", Target.window().fully().ignore_displacements(False))
@@ -111,7 +111,7 @@ def test_double_open_check_close_async_with_different_instances(
     eyes2.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleOpenCheckCloseAsyncWithDifferentInstances" + test_name_suffix,
+        "TestDoubleOpenCheckCloseAsyncWithDifferentInstances" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes2.check("Step 2", Target.window().fully().ignore_displacements(False))
@@ -121,13 +121,13 @@ def test_double_open_check_close_async_with_different_instances(
     assert len(all_test_results.all_results) == 2
 
 
-def test_double_check_dont_get_all_results(driver, eyes_runner, test_name_suffix):
+def test_double_check_dont_get_all_results(driver, eyes_runner, name_suffix):
     eyes = Eyes(eyes_runner)
     driver.get("https://applitools.com/helloworld")
     eyes.open(
         driver,
         "Applitools Eyes SDK",
-        "TestDoubleCheckDontGetAllResults" + test_name_suffix,
+        "TestDoubleCheckDontGetAllResults" + name_suffix,
         dict(width=1200, height=800),
     )
     eyes.check("Step 1", Target.window().with_name("Step 1"))

--- a/tests/functional/eyes_selenium/visual_grid/test_hello_world.py
+++ b/tests/functional/eyes_selenium/visual_grid/test_hello_world.py
@@ -1,0 +1,60 @@
+import pytest
+
+from selenium.webdriver.common.by import By
+from applitools.selenium import (
+    Eyes,
+    VisualGridRunner,
+    ClassicRunner,
+    BrowserType,
+    Configuration,
+    Target,
+)
+
+
+def pytest_generate_tests(metafunc):
+    metafunc.parametrize("eyes_runner", [ClassicRunner(), VisualGridRunner(1)])
+
+
+@pytest.fixture()
+def name_suffix(eyes_runner):
+    if isinstance(eyes_runner, ClassicRunner):
+        return ""
+    else:
+        return "_VG"
+
+
+@pytest.mark.platform("Linux")
+@pytest.mark.test_page_url("https://applitools.com/helloworld")
+def test_hello_world(eyes_runner, driver, name_suffix):
+    eyes = Eyes(eyes_runner)
+    sconf = (
+        Configuration()
+        .add_browser(800, 600, BrowserType.CHROME)
+        .add_browser(700, 500, BrowserType.FIREFOX)
+        .add_browser(1200, 800, BrowserType.IE_10)
+        .add_browser(1200, 800, BrowserType.IE_11)
+        .add_browser(1600, 1200, BrowserType.EDGE_CHROMIUM)
+        .set_app_name("Hello World Demo")
+        .set_test_name("Hello World Demo" + name_suffix)
+    )
+    eyes.set_configuration(sconf)
+    eyes.open(driver)
+
+    eyes.check(
+        "",
+        Target.window()
+        .with_name("Step 1 - Viewport")
+        .ignore([By.CSS_SELECTOR, ".primary"]),
+    )
+    eyes.check(
+        "",
+        Target.window()
+        .fully()
+        .with_name("Step 1 - Full Page")
+        .floating([By.CSS_SELECTOR, ".primary"], 10, 20, 30, 40)
+        .floating([By.TAG_NAME, "button"], 1, 2, 3, 4),
+    )
+    driver.find_element_by_tag_name("button").click()
+    eyes.check("", Target.window().with_name("Step 2 - Viewport"))
+    eyes.check("", Target.window().fully().with_name("Step 2 - Full Page"))
+    eyes.close(True)

--- a/tests/functional/resources/failedTestsSuite.yaml
+++ b/tests/functional/resources/failedTestsSuite.yaml
@@ -3,8 +3,12 @@ test_specific_cases.py:
    test_region_selector_in_check_fluent_interface:
 
 test_classic_api.py:
+   test_check_frame:
+      - VG
    test_check_inner_frame:
-      - CSS, Scroll
+      - CSS, Scroll, VG
+   test_check_region_in_frame:
+      - VG
 
 test_fluent_api.py:
    test_check_scrollable_modal:
@@ -18,7 +22,7 @@ test_other_desktop_tests.py:
 
 test_special_cases.py:
    test_check_region_in_a_very_big_frame:
-      - Scroll
+      - Scroll, VG
 
 test_runners.py:
    test_classic_runner_works_normally:
@@ -44,6 +48,10 @@ test_bad_selectors.py:
 
 test_default_rendering.py:
    test_default_rendering_of_multiple_targets:
+
+test_hello_world.py:
+   test_hello_world:
+      - [VisualGridRunner]
 
 test_vg_manager.py:
    test_vgwith_bad_webhook:


### PR DESCRIPTION
PR made next changes:
1. Add test HelloWorld and skip the same old test test_quickstart_example.
2. Update test_abort_eyes to the same test on C# to make result "Test Abort".
3. Update test_abort_async_on_vg to the same test on C# to make result "Test Abort_VG".
4. Make some tests run not only with Selenium eyes but with VG  too. If run with VG has diffs in result, add skip to it in .yaml
5. Update name of fixture from 'test_name_suffix' to 'name_suffix' due to avoid treating fixture like a test.
6. Update logic of exclude tests from run accordingly.