### PR TITLE
bugfix_trello_1879_dir_of_wrapped_element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [vNext]
+## Fixed
+- dir(eyes_driver) and dir(eyes_element) call on Python 2 raise an error [Trello 1879](https://trello.com/c/5qjuqVw9) [GH #174](https://github.com/applitools/eyes.sdk.python/pull/174)
+- element.find_elements call raise an error [Trello 1830](https://trello.com/c/s5W2pnUT) [GH #174](https://github.com/applitools/eyes.sdk.python/pull/174)
+
 ## [4.2.0] - 2020-08-18
 ### Added
 - Accessibility Validation feature [Trello 1767](https://trello.com/c/gq69woeK)

--- a/eyes_common/applitools/common/utils/general_utils.py
+++ b/eyes_common/applitools/common/utils/general_utils.py
@@ -105,7 +105,7 @@ def proxy_to(proxy_obj_name, fields=None):
 
     def __dir__(self):
         _fields = fields or self._proxy_to_fields or []
-        origin_fields = super(self.__class__, self).__dir__()
+        origin_fields = dir(self.__class__)
         return list(origin_fields) + _fields
 
     def dec(cls):

--- a/eyes_selenium/applitools/selenium/webdriver.py
+++ b/eyes_selenium/applitools/selenium/webdriver.py
@@ -379,11 +379,11 @@ class EyesWebDriver(object):
         :return: A element denoted by "By".
         """
         # Get result from the original implementation of the underlying driver.
-        result = self._driver.find_element(by, value)
+        element = self._driver.find_element(by, value)
         # Wrap the element.
-        if result:
-            result = EyesWebElement(result, self)
-        return result
+        if element:
+            element = EyesWebElement(element, self)
+        return element
 
     def find_elements(self, by=By.ID, value=None):
         # type: (Text, Text) -> List[EyesWebElement]
@@ -395,14 +395,11 @@ class EyesWebDriver(object):
         :return: List of elements denoted by "By".
         """
         # Get result from the original implementation of the underlying driver.
-        results = self._driver.find_elements(by, value)
+        elements = self._driver.find_elements(by, value)
         # Wrap all returned elements.
-        if results:
-            updated_results = []
-            for element in results:
-                updated_results.append(EyesWebElement(element, self))
-            results = updated_results
-        return results
+        if elements:
+            elements = [EyesWebElement(el, self) for el in elements]
+        return elements
 
     def find_element_by_id(self, id_):
         # type: (Text) -> EyesWebElement

--- a/eyes_selenium/applitools/selenium/webelement.py
+++ b/eyes_selenium/applitools/selenium/webelement.py
@@ -93,7 +93,7 @@ class EyesWebElement(object):
             element = element._element
         self._proxy_to_fields = all_attrs(element)
         self._element = element  # type: WebElement
-        self._driver = driver  # type: EyesWebDriver
+        self._eyes_driver = driver  # type: EyesWebDriver
 
         # setting from outside
         self.position_provider = None  # type: Optional[SeleniumPositionProvider]
@@ -107,7 +107,7 @@ class EyesWebElement(object):
     @property
     def driver(self):
         # type: () -> EyesWebDriver
-        return self._driver
+        return self._eyes_driver
 
     @property
     def bounds(self):
@@ -171,12 +171,7 @@ class EyesWebElement(object):
         :param value: The value to search for.
         :return: WebElement denoted by "By".
         """
-        # Get result from the original implementation of the underlying driver.
-        result = self._driver.find_element(by, value)
-        # Wrap the element.
-        if result:
-            result = EyesWebElement(result, self._driver)
-        return result
+        return self._eyes_driver.find_element(by, value)
 
     def find_elements(self, by=By.ID, value=None):
         """
@@ -186,21 +181,13 @@ class EyesWebElement(object):
         :param value: The value to search for.
         :return: List of web elements denoted by "By".
         """
-        # Get result from the original implementation of the underlying driver.
-        results = self._original_methods["find_elements"](by, value)
-        # Wrap all returned elements.
-        if results:
-            updated_results = []
-            for element in results:
-                updated_results.append(EyesWebElement(element, self._driver))
-            results = updated_results
-        return results
+        return self._eyes_driver.find_elements(by, value)
 
     def click(self):
         """
         Clicks and element.
         """
-        self._driver.eyes.add_mouse_trigger_by_element("click", self)
+        self._eyes_driver.eyes.add_mouse_trigger_by_element("click", self)
         self._element.click()
 
     def send_keys(self, *value):
@@ -214,7 +201,7 @@ class EyesWebElement(object):
             if isinstance(val, int):
                 val = val.__str__()
             text += val.encode("utf-8").decode("utf-8")
-        self._driver.eyes.add_text_trigger_by_element(self, text)
+        self._eyes_driver.eyes.add_text_trigger_by_element(self, text)
         self._element.send_keys(*value)
 
     def hide_scrollbars(self):
@@ -237,7 +224,7 @@ class EyesWebElement(object):
 
     def get_computed_style(self, prop_style):
         script = _JS_GET_COMPUTED_STYLE_FORMATTED_STR % prop_style
-        return self._driver.execute_script(script, self._element)
+        return self._eyes_driver.execute_script(script, self._element)
 
     def get_computed_style_int(self, prop_style):
 
@@ -246,20 +233,28 @@ class EyesWebElement(object):
 
     def get_scroll_left(self):
         return int(
-            math.ceil(self._driver.execute_script(_JS_GET_SCROLL_LEFT, self._element))
+            math.ceil(
+                self._eyes_driver.execute_script(_JS_GET_SCROLL_LEFT, self._element)
+            )
         )
 
     def get_scroll_top(self):
-        return math.ceil(self._driver.execute_script(_JS_GET_SCROLL_TOP, self._element))
+        return math.ceil(
+            self._eyes_driver.execute_script(_JS_GET_SCROLL_TOP, self._element)
+        )
 
     def get_scroll_width(self):
         return int(
-            math.ceil(self._driver.execute_script(_JS_GET_SCROLL_WIDTH, self._element))
+            math.ceil(
+                self._eyes_driver.execute_script(_JS_GET_SCROLL_WIDTH, self._element)
+            )
         )
 
     def get_scroll_height(self):
         return int(
-            math.ceil(self._driver.execute_script(_JS_GET_SCROLL_HEIGHT, self._element))
+            math.ceil(
+                self._eyes_driver.execute_script(_JS_GET_SCROLL_HEIGHT, self._element)
+            )
         )
 
     def get_border_left_width(self):
@@ -275,26 +270,34 @@ class EyesWebElement(object):
         return self.get_computed_style_int("border-right-width")
 
     def get_overflow(self):
-        return self._driver.execute_script(_JS_GET_OVERFLOW, self._element)
+        return self._eyes_driver.execute_script(_JS_GET_OVERFLOW, self._element)
 
     def get_client_width(self):
         return int(
             math.ceil(
-                float(self._driver.execute_script(_JS_GET_CLIENT_WIDTH, self._element))
+                float(
+                    self._eyes_driver.execute_script(
+                        _JS_GET_CLIENT_WIDTH, self._element
+                    )
+                )
             )
         )
 
     def get_client_height(self):
         return int(
             math.ceil(
-                float(self._driver.execute_script(_JS_GET_CLIENT_HEIGHT, self._element))
+                float(
+                    self._eyes_driver.execute_script(
+                        _JS_GET_CLIENT_HEIGHT, self._element
+                    )
+                )
             )
         )
 
     def scroll_to(self, location):
         # type: (Point) -> Point
         """Scrolls to the specified location inside the element."""
-        position = self._driver.execute_script(
+        position = self._eyes_driver.execute_script(
             _JS_SCROLL_TO_FORMATTED_STR.format(location["x"], location["y"])
             + _JS_GET_SCROLL_POSITION,
             self._element,
@@ -304,7 +307,7 @@ class EyesWebElement(object):
     @property
     def size_and_borders(self):
         # type: () -> SizeAndBorders
-        ret_val = self._driver.execute_script(
+        ret_val = self._eyes_driver.execute_script(
             _JS_GET_SIZE_AND_BORDER_WIDTHS, self._element
         )
         return SizeAndBorders(

--- a/tests/functional/eyes_selenium/selenium/test_wrappers.py
+++ b/tests/functional/eyes_selenium/selenium/test_wrappers.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
 
 from applitools.selenium import EyesWebDriver
 
@@ -48,3 +49,17 @@ def test_driver_and_element_dir(eyes, driver):
     eyes_element = eyes_driver.find_element_by_xpath("//div[@class='content']")
     _dir = dir(eyes_element)
     assert all(elem in _dir for elem in dir(element) if not elem.startswith("_"))
+
+
+def test_eyes_element_and_element_with_Select(eyes, driver):
+    driver.get("https://the-internet.herokuapp.com/dropdown")
+
+    eyes_driver = EyesWebDriver(driver, eyes)
+
+    element = driver.find_element_by_xpath("//select[contains(@id, 'dropdown')]")
+    my_select = Select(element)
+
+    eyes_element = eyes_driver.find_element_by_xpath(
+        "//select[contains(@id, 'dropdown')]"
+    )
+    my_select = Select(eyes_element)

--- a/tests/functional/eyes_selenium/selenium/test_wrappers.py
+++ b/tests/functional/eyes_selenium/selenium/test_wrappers.py
@@ -35,3 +35,16 @@ def test_element_find_element(eyes, driver):
     # Locate element
     element = eyes_driver.find_element_by_xpath("//div[@class='content']")
     element.find_element(By.XPATH, "//a[contains(@href, " "'request-demo')]").click()
+
+
+def test_driver_and_element_dir(eyes, driver):
+    driver.get("https://applitools.com/")
+
+    eyes_driver = EyesWebDriver(driver, eyes)
+    _dir = dir(eyes_driver)
+    assert all(elem in _dir for elem in dir(driver) if not elem.startswith("_"))
+
+    element = driver.find_element_by_xpath("//div[@class='content']")
+    eyes_element = eyes_driver.find_element_by_xpath("//div[@class='content']")
+    _dir = dir(eyes_element)
+    assert all(elem in _dir for elem in dir(element) if not elem.startswith("_"))

--- a/tests/functional/eyes_selenium/selenium/test_wrappers.py
+++ b/tests/functional/eyes_selenium/selenium/test_wrappers.py
@@ -38,6 +38,21 @@ def test_element_find_element(eyes, driver):
     element.find_element(By.XPATH, "//a[contains(@href, " "'request-demo')]").click()
 
 
+def test_eyes_element_and_element_with_Select(eyes, driver):
+    driver.get("https://the-internet.herokuapp.com/dropdown")
+
+    eyes_driver = EyesWebDriver(driver, eyes)
+
+    element = driver.find_element_by_xpath("//select[contains(@id, 'dropdown')]")
+    my_select = Select(element)
+    my_select.options
+    eyes_element = eyes_driver.find_element_by_xpath(
+        "//select[contains(@id, 'dropdown')]"
+    )
+    my_select = Select(eyes_element)
+    my_select.options
+
+
 def test_driver_and_element_dir(eyes, driver):
     driver.get("https://applitools.com/")
 
@@ -49,17 +64,3 @@ def test_driver_and_element_dir(eyes, driver):
     eyes_element = eyes_driver.find_element_by_xpath("//div[@class='content']")
     _dir = dir(eyes_element)
     assert all(elem in _dir for elem in dir(element) if not elem.startswith("_"))
-
-
-def test_eyes_element_and_element_with_Select(eyes, driver):
-    driver.get("https://the-internet.herokuapp.com/dropdown")
-
-    eyes_driver = EyesWebDriver(driver, eyes)
-
-    element = driver.find_element_by_xpath("//select[contains(@id, 'dropdown')]")
-    my_select = Select(element)
-
-    eyes_element = eyes_driver.find_element_by_xpath(
-        "//select[contains(@id, 'dropdown')]"
-    )
-    my_select = Select(eyes_element)


### PR DESCRIPTION
This PR fixes two issues. One related to getting an exception during the call for dir(eyes_driver) and dir(eyes_element) on Python 2. The second issue is related to calling `eyes_element.find_elements` raised an exception.