### PR TITLE
Generic tests teardown - add get_all_test_results

### DIFF
--- a/coverage-tests/test/conftest.py
+++ b/coverage-tests/test/conftest.py
@@ -268,4 +268,5 @@ def eyes_setup(runner, batch_info, stitch_mode, emulation):
     yield eyes
     # If the test was aborted before eyes.close was called, ends the test as aborted.
     eyes.abort_if_not_closed()
-    if runner is not None: runner.get_all_test_results(False)
+    if runner is not None:
+        runner.get_all_test_results(False)

--- a/coverage-tests/test/conftest.py
+++ b/coverage-tests/test/conftest.py
@@ -268,4 +268,4 @@ def eyes_setup(runner, batch_info, stitch_mode, emulation):
     yield eyes
     # If the test was aborted before eyes.close was called, ends the test as aborted.
     eyes.abort_if_not_closed()
-    runner.get_all_test_results(False)
+    if runner is not None: runner.get_all_test_results(False)

--- a/coverage-tests/test/conftest.py
+++ b/coverage-tests/test/conftest.py
@@ -268,3 +268,4 @@ def eyes_setup(runner, batch_info, stitch_mode, emulation):
     yield eyes
     # If the test was aborted before eyes.close was called, ends the test as aborted.
     eyes.abort_if_not_closed()
+    runner.get_all_test_results(False)


### PR DESCRIPTION
Add get_all_test_results to generic tests teardown(according to request of itai.barhaim  2:38 PM 17 February in slack-chat  sdk-dev-general). Here is successful run - https://travis-ci.com/github/applitools/eyes.sdk.python/builds/220463241